### PR TITLE
Fixing "Sinatra doesn’t know this ditty."

### DIFF
--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -42,5 +42,5 @@
             %a{:href => url_for("/node/fetch/#{node[:full_name]}") }
               %span{:class=>'glyphicon glyphicon-cloud-download'}
           %td
-            %a{:href => url_for("/node/next/#{node[:full_name]}") }
+            %a{:href => url_for("/node/next/#{node[:name]}") }
               %span{:class=>'glyphicon glyphicon-repeat'}


### PR DESCRIPTION
Manual update link is broken, it includes the group name if one is used. The correct URL appears to be the node of the node, not including the group.