### PR TITLE
Rancid migration Feature

### DIFF
--- a/lib/oxidized/web/mig.rb
+++ b/lib/oxidized/web/mig.rb
@@ -1,0 +1,149 @@
+module Oxidized
+  module API
+    class Mig
+      def initialize(hash_router_db, cloginrc, path_new_router)
+        @hash_router_db = hash_router_db
+        @cloginrc = cloginrc
+        @path_new_router = path_new_router
+      end
+      
+      #read cloginrc and return a hash with node name, which a hash value which contains user, password, eventually enable
+      def cloginrc clogin_file
+        close_file = clogin_file
+        file = close_file.read
+        file = file.gsub("add", '')
+        
+        hash = {}
+        file.each_line do |line|
+          
+          
+          #stock all device name, and password and enable if there is one
+          line = line.split(" ")
+          for i in 0..line.length
+            if line[i] == "user"
+              #add the equipment and user if not exist
+              unless hash[line[i + 1]]
+                hash[line[i + 1]] = {:user=>line[i + 2]}
+              end
+            #if the equipment exist, add password and enable password
+            elsif line[i] == "password"
+              if hash[line[i + 1]]
+                if line.length > i + 2
+                  h = hash[line[i + 1]]
+                  h[:password] = line[i + 2]
+                  if /\s*/.match(line[i + 3])
+                    h[:enable] = line[i + 3]
+                  end
+                  hash[line[i + 1]] = h
+                elsif line.length = i + 2
+                  h = hash[line[i + 1]]
+                  h[:password] = line[i + 2]
+                  hash[line[i + 1]] = h
+                end
+              end
+            end
+          end
+        end
+        close_file.close
+        hash
+      end
+      def model_dico model
+        dico = {"cisco"=>"ios", "foundry"=>"ironware"}
+        model = model.gsub("\n", "")
+        if dico[model]
+          model = dico[model]
+        end
+        model
+      end
+      
+      #add node and group for an equipment (take a list of router.db)
+      def rancid_group router_db_list
+        model = {}
+        hash = cloginrc @cloginrc
+        router_db_list.each do |router_db|
+          group = router_db[:group]
+          file_close = router_db[:file]
+          file = file_close.read
+          file = file.gsub(":up", '')
+          file.gsub(" ", '')
+          
+          file.each_line do |line|
+            line = line.split(":")
+            node = line[0]
+            if hash[node]
+              h = hash[node]
+              model = model_dico line[1].to_s
+              h[:model] = model
+              h[:group] = group
+            end
+          end
+          file_close.close
+        end
+        hash
+      end
+      
+      #write a router.db conf, need the hash and the path of the file we whish create
+      def write_router_db hash
+        router_db = File.new(@path_new_router, "w")
+        hash.each do |key, value|
+          line = key.to_s
+          line += ":" + value[:model].to_s
+          line += ":" + value[:user].to_s
+          line += ":" + value[:password].to_s
+          line += ":" + value[:group].to_s
+          if value[:enable]
+            line += ":" + value[:enable].to_s
+          end
+          router_db.puts(line)
+        end
+        router_db.close
+      end
+      
+      def edit_conf_file path_conf, router_db_path
+        file_close = File.open(path_conf, "r")
+        file = file_close
+        file = file.read
+        source_reached = false
+        new_file = []
+        file.each_line do |line|
+          if source_reached
+            unless /^\w/.match(line)
+              next
+            end
+            source_reached = false
+          end
+          new_file.push(line)
+          if /source:/.match(line)
+            source_reached = true
+            new_file.push("  default: csv\n")
+            new_file.push("  csv:\n")
+            new_file.push("    file: " + router_db_path + "\n")
+            new_file.push("    delimiter: !ruby/regexp /:/\n")
+            new_file.push("    map:\n")
+            new_file.push("      name: 0\n")
+            new_file.push("      model: 1\n")
+            new_file.push("      username: 2\n")
+            new_file.push("      password: 3\n")
+            new_file.push("      group: 4\n")
+            new_file.push("    vars_map:\n")
+            new_file.push("      enable: 5\n")
+            next
+          end
+        end
+        file_close.close
+        
+        new_conf = File.new(path_conf, "w")
+        new_file.each do |line|
+          new_conf.puts(line)
+        end
+        new_conf.close
+      end
+      
+      def go_rancid_migration
+        hash = rancid_group @hash_router_db
+        write_router_db hash
+        edit_conf_file "#{ENV['HOME']}/.config/oxidized/config", @path_new_router
+      end
+    end
+  end
+end

--- a/lib/oxidized/web/public/css/dataTables.colVis.css
+++ b/lib/oxidized/web/public/css/dataTables.colVis.css
@@ -81,7 +81,7 @@ ul.ColVis_collection {
 	border: 1px solid #ccc;
 	border: 1px solid rgba( 0, 0, 0, 0.4 );
 	background-color: #f3f3f3;
-	background-color: rgba( 255, 255, 255, 0.3 );
+	background-color: rgb( 255, 255, 255);
 	overflow: hidden;
 	z-index: 2002;
 

--- a/lib/oxidized/web/public/scripts/script-migration.js
+++ b/lib/oxidized/web/public/scripts/script-migration.js
@@ -1,0 +1,15 @@
+var number = 1;
+
+function add_file_upload(){
+	number++;
+	document.getElementById('number').value = number;
+	var table = document.getElementById("files");
+	var row = table.insertRow(-1);
+	var group = row.insertCell(0);
+	group.id = "file";
+	var file = row.insertCell(1);
+	file.id = "file";
+	group.innerHTML = '<input type="text" name="group' + number +'" value="default">';
+	file.innerHTML = '<input type="file" name="file' + number +'" required >';
+	
+}

--- a/lib/oxidized/web/views/migration.haml
+++ b/lib/oxidized/web/views/migration.haml
@@ -1,0 +1,41 @@
+!=haml :head
+%script{:src=>url_for('/scripts/script-migration.js')}
+%body
+  
+  %span{:id=>"migration_span"}
+    Here you can migrate from your Rancid to Oxidized.
+    %br
+    To do it, just execute te following actions :
+  %br
+  %br
+  %form(method="post" enctype="multipart/form-data")
+    %label{:for=>"path_new_file"} Set the path for your future equipement file in .db format
+    %br
+    %input{:type=>"text", :name=>"path_new_file", :value=>"Path/to_file/here.db"}
+    %br
+    %br
+    %label{:for=>"cloginrc"} Select your .cloginrc file, must be readeable
+    %input{:type=>"file", :name=>"cloginrc"}
+    %br
+    %label{:for=>"files"} Select all your router.db fies of rancid, and add their group (Click "Add file" if you have multiple files)
+    %table{:id=>"files", :name=>"files"}
+      %th{:id=>"file"} Group
+      %th{:id=>"file"} File
+      %tbody
+        %tr
+          %td{:id=>"file"}
+            %input{:type=>"text", :name=>"group1", :value=>"default"}
+          %td{:id=>"file"}
+            %input{:type=>"file", :name=>"file1", :required=>""}
+    %br
+    %input(type='button' value ='Add file' onclick="add_file_upload();")
+    %br
+    %br
+    %label{:for=>"upload_button"}Then Click "Migrate" to do your migration
+    %br
+    %input(type='submit' value='Migrate !' id="upload_button")
+    /
+      used to know the numbers of files router.db
+    %input(type='hidden' value='1' id='number' name='number')
+    
+  

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -21,7 +21,8 @@
 %div{:class=>'row tbl-header'}
   %div{:class=>'col-xs-12 col-md-2'}
     %h4 nodes /
-  
+%button{:onclick => "location.href='/migration'" }
+  %span migration
 %div{:class=>'row'}
   %div{:class=>'refresh-div'}
     %form

--- a/lib/oxidized/web/views/sass/oxidized.sass
+++ b/lib/oxidized/web/views/sass/oxidized.sass
@@ -72,3 +72,19 @@ input#search .focused
 a:hover
     text-decoration: none 
 
+#migration_span
+    font-size: 20px
+    font-weight: bold
+    
+table#files
+    width: 70%
+    border: 1px solid
+    
+th#file
+    width: 50%
+    height: 30px
+    text-align: center
+
+td#file
+    @extend th#file
+    padding: 15px

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -4,6 +4,8 @@ require 'sinatra/url_for'
 require 'haml'
 require 'sass'
 require 'pp'
+require 'pp'
+require 'oxidized/web/mig'
 module Oxidized
   module API
     class WebApp < Sinatra::Base
@@ -84,7 +86,32 @@ module Oxidized
         @data = nodes.show node
         out :node
       end
+      
+      #redirect to the web page for rancid - oxidized migration
+      get '/migration' do
+        out :migration
+      end
+      
+      #get the files send
+      post '/migration' do
+        number = params[:number].to_i
+        cloginrc_file = params['cloginrc'][:tempfile]
+        path_new_file = params['path_new_file']
 
+        router_db_files = Array.new
+        
+        i = 1
+        while i <= number do
+          router_db_files.push({:file=>(params["file"+i.to_s][:tempfile]), :group=>params["group"+i.to_s]})
+          i = i+1
+        end
+
+        migration = Mig.new(router_db_files, cloginrc_file, path_new_file)
+        migration.go_rancid_migration
+        redirect url_for("//nodes")
+     
+      end
+      
       get '/css/*.css' do
         sass "sass/#{params[:splat].first}".to_sym
       end


### PR DESCRIPTION
Feature to migrate form Rancid to Oxidized.
You can create a first router.db with fake equipment just to access to the web interface, and then click on the migration button and follow the instructions. (You must restart oxidized after of course)

Below the page with the instructions : 

![migration_page](https://cloud.githubusercontent.com/assets/10435273/8034311/bed870ae-0de6-11e5-8a85-8683afb47a74.png)

