### PR TITLE
Add Stats Link and Update Interface

### DIFF
--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -9,6 +9,8 @@
 	      %li
                 %a{:class=>'navbar-brand', :href=>url_for('/')}
                   %img{:src=>url_for('/images/oxidizing_40px.png')} Oxidized
+              %li{:class=>request.path_info == '/nodes/stats' ? 'active' : ''}
+                %a{:class=>'navbar-link', :href=>url_for('/nodes/stats')} Stats
 	      %li
 	        %a{:class=>'navbar-link', :href=>url_for('/migration')} Migration
             %form{:class=>'navbar-form navbar-right', :role=>'search',
@@ -22,3 +24,4 @@
 		  %span{:class=>'glyphicon glyphicon-search'}
     %div{:class=>'container'}
       =yield
+

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -1,10 +1,10 @@
-%div.row.tbl-header
-  %div.col-xs-12
+.row.tbl-header
+  .col-xs-12
     %h4
       %a{href: url_for('/nodes')} nodes
       \/ stats
-%div.row
-  %table.table.table-responsive.tablesorter{id: 'versionsTable'}
+.row
+  %table.table.table-responsive.tablesorter#versionsTable
     %caption
       %span Failures in Previous 24 Hours
       %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
@@ -14,14 +14,14 @@
       %tr
         %th Name
         %th Last Success
-      %tbody
-        - @data.select do |node, stats|
-          - not stats[:success] or (stats[:success].last[:end] < Time.now.utc-60*60*24)
-        - end.map do |node, stats|
-          - last = stats[:success] ? last.last[:end] : 'never'
-          %tr
-            %td= node
-            %td= last
+    %tbody
+      - @data.select do |node, stats|
+        - not stats[:success] or (stats[:success].last[:end] < Time.now.utc-60*60*24)
+      - end.map do |node, stats|
+        - last = stats[:success] ? last.last[:end] : 'never'
+        %tr
+          %td= node
+          %td= last
 :javascript
   $(function(){
     $("#statsTable").tablesorter();

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -1,23 +1,29 @@
-%html
-  !=haml :head
-  %body
-    %h1 no success in a day
-    %table{:id=>'statsTable', :class=>'center tablesorter'}
-      %thead
-        %tr
-          %th Name
-          %th Last success
+%div.row.tbl-header
+  %div.col-xs-12
+    %h4
+      %a{href: url_for('/nodes')} nodes
+      \/ stats
+%div.row
+  %table.table.table-responsive.tablesorter{id: 'versionsTable'}
+    %caption
+      %span Failures in Previous 24 Hours
+      %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
+        %span.glyphicon.glyphicon-repeat
+        Refresh
+    %thead
+      %tr
+        %th Name
+        %th Last Success
       %tbody
-        -@data.select do |node,stats|
+        - @data.select do |node, stats|
           - not stats[:success] or (stats[:success].last[:end] < Time.now.utc-60*60*24)
-        - end.map do |node,stats|
-          - last = stats[:success]
-          - last = last.last[:end] if last
-          - last ||= 'never'
+        - end.map do |node, stats|
+          - last = stats[:success] ? last.last[:end] : 'never'
           %tr
             %td= node
             %td= last
-    :javascript
-      $(function(){
-        $("#statsTable").tablesorter();
-      });
+:javascript
+  $(function(){
+    $("#statsTable").tablesorter();
+  });
+


### PR DESCRIPTION
Closes #44.

This PR adds a link to the stats page and updates the interface to be more akin to the newer UI.  Screenshot below.

![new-stats-page](https://cloud.githubusercontent.com/assets/4076147/12013996/bd658a82-acd7-11e5-81e6-613a033a38fa.PNG)
