### PR TITLE
Support regexes in searches.

### DIFF
--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -46,13 +46,13 @@ module Oxidized
       end
 
       post '/nodes/conf_search' do
-        @to_research = params[:search_in_conf_textbox]
+        @to_research = Regexp.new params[:search_in_conf_textbox]
         nodes_list = nodes.list.map
         @nodes_match = []
         nodes_list.each do |n|
           node, @json = route_parse n[:name]
           config = nodes.fetch node, n[:group]
-          if config.include? @to_research
+          if config[@to_research]
             @nodes_match.push({:node => n[:name], :full_name => n[:full_name]})
           end
         end


### PR DESCRIPTION
Closes #33.

Convert the search parameter to a Regex and use `String#[]` to look for a match.

I'm also open to searching to see if the string begins and ends with `/` and only converting to a Regex then, but this seems "easier."