### PR TITLE
Convert UTC to browser timezone.

### DIFF
--- a/lib/oxidized/web/public/scripts/oxidized.js
+++ b/lib/oxidized/web/public/scripts/oxidized.js
@@ -1,0 +1,19 @@
+// Convert UTC times to local browser times
+// Requires that the times on the server are UTC
+// Requires a class name of `time` to be set on element desired to be changed
+// Requires that element have a text in the format of `YYYY-mm-dd HH:MM:SS`
+// See ytti/oxidized-web #16
+$(function() {
+  $('.time').each(function() {
+    var utcTime = $(this).text().split(' ');
+    var date = new Date(utcTime[0] + 'T' + utcTime[1] + 'Z');
+    var year = date.getFullYear();
+    var month = ("0"+(date.getMonth()+1)).slice(-2);
+    var day = ("0" + date.getDate()).slice(-2);
+    var hour = ("0" + date.getHours()).slice(-2);
+    var minute = ("0" + date.getMinutes()).slice(-2);
+    var second = ("0" + date.getSeconds()).slice(-2);
+    var timeZone = date.toString().match(/\(.*\)/)[0].match(/[A-Z]/g).join('');
+    $(this).text(year + '-' + month + '-' + day + ' ' + hour + ':' + minute + ':' + second + ' ' + timeZone);
+  });
+});

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -1,69 +1,68 @@
-!=haml :head
-%body
-  %h4
-    - node_full = ''
-    - if @info[:group] != ''
-      - node_full = "#{@info[:group] + '/' + @info[:node]}"
+%h4
+  - node_full = ''
+  - if @info[:group] != ''
+    - node_full = "#{@info[:group] + '/' + @info[:node]}"
+  - else
+    - node_full = "#{@info[:node]}"
+  %a{:href=>url_for("/node/version?node_full=#{node_full}")} versions
+  \/ Diff version #{@info[:num]} - #{@info[:num2]} for Node 
+  %span{:class=>'node_title'} #{@info[:node]}
+- date_version = Time.parse @info[:date]
+Date of version:
+%span.time #{date_version.strftime("%d-%m-%y at %r")}
+%br
+Number of lines changed: 
+%span{:class=>'added'}added #{@stat[0]} 
+%span{:class=>'deleted'}removed #{@stat[1]}
+%br
+%br
+%form{ :action => "/node/version/diffs?node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}&date=#{@info[:date]}&num=#{@info[:num]}", :method => "post"}
+  %select{:name => "oid2", :id => "oid2"}
+    - diff2 = {}
+    - num = @oids_dates.count + 1
+    - next_id = false
+    - @oids_dates.each do |x|
+      %option{:value => x[:oid]} Version #{num -= 1} (#{time_from_now x[:date]})
+      - if (x[:oid].to_s == @info[:oid2]) || (next_id)
+        - diff2 = {:num => num, :date => x[:date]}
+        - next_id = false
+      - elsif (x[:oid].to_s == @info[:oid]) && !(@info[:oid2])
+        - next_id = true
+      
+        
+  %input{:type => "submit", :value => "Get diffs !"}
+%br
+%div{:class=>'old_version_title'} Version #{diff2[:num]} (#{time_from_now diff2[:date]})
+%div{:class=>'new_version_title'} Version #{@info[:num]} (#{time_from_now @info[:date]})
+%br
+%div{:class=>'diffs_old', :id=>'Test'}
+  - @diff[:old_diff].each do |line|
+    - if /^\+.*/.match(line)
+      %div{:class=>'added',:id=>'Test'}> #{line}
+      
+    - elsif /^\-.*/.match(line)
+      %div{:class=>'deleted'}> #{line}
+      
+    - elsif /^@@\s.*@@.*$/.match(line)
+      %div{:class=>'diff-index', :id=>'Test'}> #{line}
+    - elsif /^empty_line&nbsp;/.match(line)
+      - line.slice! "empty_line"
+      %div{:class=>'diff-empty'}> #{line}
     - else
-      - node_full = "#{@info[:node]}"
-    %a{:href=>url_for("/node/version?node_full=#{node_full}")} versions
-    \/ Diff version #{@info[:num]} - #{@info[:num2]} for Node 
-    %span{:class=>'node_title'} #{@info[:node]}
-  - date_version = Time.parse @info[:date]
-  Date of version: #{date_version.strftime("%d-%m-%y at %r")}
-  %br
-  Number of lines changed: 
-  %span{:class=>'added'}added #{@stat[0]} 
-  %span{:class=>'deleted'}removed #{@stat[1]}
-  %br
-  %br
-  %form{ :action => "/node/version/diffs?node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}&date=#{@info[:date]}&num=#{@info[:num]}", :method => "post"}
-    %select{:name => "oid2", :id => "oid2"}
-      - diff2 = {}
-      - num = @oids_dates.count + 1
-      - next_id = false
-      - @oids_dates.each do |x|
-        %option{:value => x[:oid]} Version #{num -= 1} (#{time_from_now x[:date]})
-        - if (x[:oid].to_s == @info[:oid2]) || (next_id)
-          - diff2 = {:num => num, :date => x[:date]}
-          - next_id = false
-        - elsif (x[:oid].to_s == @info[:oid]) && !(@info[:oid2])
-          - next_id = true
-        
-          
-    %input{:type => "submit", :value => "Get diffs !"}
-  %br
-  %div{:class=>'old_version_title'} Version #{diff2[:num]} (#{time_from_now diff2[:date]})
-
-  %div{:class=>'new_version_title'} Version #{@info[:num]} (#{time_from_now @info[:date]})
-  %br
-  %div{:class=>'diffs_old', :id=>'Test'}
-    - @diff[:old_diff].each do |line|
-      - if /^\+.*/.match(line)
-        %div{:class=>'added',:id=>'Test'}> #{line}
-        
-      - elsif /^\-.*/.match(line)
-        %div{:class=>'deleted'}> #{line}
-        
-      - elsif /^@@\s.*@@.*$/.match(line)
-        %div{:class=>'diff-index', :id=>'Test'}> #{line}
-      - elsif /^empty_line&nbsp;/.match(line)
-        - line.slice! "empty_line"
-        %div{:class=>'diff-empty'}> #{line}
-      - else
-        %div> #{line}
-  %div{:class=>'diffs_new'}
-    -  @diff[:new_diff].each do |line|
-      - if /^\+.*/.match(line)
-        %div{:class=>'added'}> #{line}
-      
-      - elsif /^\-.*/.match(line)
-        %div{:class=>'deleted'}> #{line}
-      
-      - elsif /^@@\s.*@@.*$/.match(line)
-        %div{:class=>'diff-index'}> #{line}
-      - elsif /^empty_line&nbsp;/.match(line)
-        - line.slice! "empty_line"
-        %div{:class=>'diff-empty'}> #{line}
-      - else
-        %div> #{line}
+      %div> #{line}
+%div{:class=>'diffs_new'}
+  -  @diff[:new_diff].each do |line|
+    - if /^\+.*/.match(line)
+      %div{:class=>'added'}> #{line}
+    
+    - elsif /^\-.*/.match(line)
+      %div{:class=>'deleted'}> #{line}
+    
+    - elsif /^@@\s.*@@.*$/.match(line)
+      %div{:class=>'diff-index'}> #{line}
+    - elsif /^empty_line&nbsp;/.match(line)
+      - line.slice! "empty_line"
+      %div{:class=>'diff-empty'}> #{line}
+    - else
+      %div> #{line}
+%script{:src=>url_for('/scripts/jquery-2.1.1.min.js')}

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -24,4 +24,4 @@
 		  %span{:class=>'glyphicon glyphicon-search'}
     %div{:class=>'container'}
       =yield
-
+    %script{:src=>url_for('/scripts/oxidized.js')}

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -46,7 +46,7 @@
           %td
             %div{:title=>node[:status], :class=>node[:status]}
               %span{:style=>'visibility: hidden'}#{node[:status]}
-          %td= node[:time]
+          %td{:class=>'time'}= node[:time]
           %td
             %a{:title => "configuration", :href => url_for("/node/fetch/#{node[:full_name]}") }
               %span{:class=>'glyphicon glyphicon-cloud-download'}

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -1,19 +1,17 @@
-!=haml :head
-%body
-  %h4
-    - if @info[:group] != ''
-      %a{:href=>url_for("/node/version?node_full=#{@info[:group] + '/' + @info[:node]}")} versions
-    - else    
-      %a{:href=>url_for("/node/version?node_full=#{@info[:node]}")} versions
-    \/ version #{@info[:num]}  for Node 
-    %span{:class=>'node_title'} #{@info[:node]}
-    
-  - date_version = Time.parse @info[:date]
-  Date of version: #{date_version.strftime("%d-%m-%y at %r")}
-  %br
-  %br
-  %div{:class=>'diffs'}
-    - @data.each_line do |line|
-      %div> #{line}
-
+%h4
+  - if @info[:group] != ''
+    %a{:href=>url_for("/node/version?node_full=#{@info[:group] + '/' + @info[:node]}")} versions
+  - else    
+    %a{:href=>url_for("/node/version?node_full=#{@info[:node]}")} versions
+  \/ version #{@info[:num]}  for Node 
+  %span{:class=>'node_title'} #{@info[:node]}
   
+- date_version = Time.parse @info[:date]
+Date of version: 
+%span.time #{date_version.strftime('%Y-%m-%d %H:%M:%S %Z')}
+%br
+%br
+%div{:class=>'diffs'}
+  - @data.each_line do |line|
+    %div> #{line}
+%script{:src=>url_for('/scripts/jquery-2.1.1.min.js')}


### PR DESCRIPTION
Closes #16.

Add new javascript file to contain code specific to oxidized-web.
Convert anything set with the `.time` class from UTC to local time.
Unifies absolute time output across web UI.
Requires that the server running oxidized-web to be set to UTC time.
Remove body and include head tags as these may cause issues.