### PR TITLE
Add More Stats

### DIFF
--- a/lib/oxidized/web/views/conf_search.haml
+++ b/lib/oxidized/web/views/conf_search.haml
@@ -5,20 +5,19 @@
       "order": [[ 0, "desc" ]]
     });
   });
-%div{:class=>'row tbl-header'}
-  %div{:class=>'col-xs-12 '}
+.row.tbl-header
+  .col-xs-12
     %h4
       %a{:href=>url_for('/nodes')} nodes
       \/ Nodes that contain 
       %span " #{@to_research} "
   
-%div{:class=>'row'}
-  %div{:class=>'refresh-div'}
+.row
+  .refresh-div
     %form
-      %button{:class => "ColVis_Button", :type => "button", :onclick => "history.go();"}
-        %span{:class=>"glyphicon glyphicon-repeat"}
-        Refresh
-  %table{:id=>'versionsTable', :class=>'table table-responsive tablesorter'}
+      %button.ColVis_Button{:type => "button", :onclick => "history.go();"}
+        %span.glyphicon.glyphicon-repeat Refresh
+  %table.table.table-responsive.tablesorter#versionsTable
     %thead
       %tr
         %th Name
@@ -32,6 +31,6 @@
             #{x[:node]}
           %td
             %a{:title => "configuration", :href => url_for("/node/fetch/#{x[:full_name]}") }
-              %span{:class=>'glyphicon glyphicon-cloud-download'} 
+              %span.glyphicon.glyphicon-cloud-download
 
-          
+

--- a/lib/oxidized/web/views/conf_search.haml
+++ b/lib/oxidized/web/views/conf_search.haml
@@ -1,10 +1,3 @@
-:javascript
-  $(function() {
-    $('#versionsTable').dataTable({
-      dom: 'C<"clear">lfrtip',
-      "order": [[ 0, "desc" ]]
-    });
-  });
 .row.tbl-header
   .col-xs-12
     %h4
@@ -32,5 +25,11 @@
           %td
             %a{title: 'configuration', href: url_for("/node/fetch/#{x[:full_name]}")}
               %span.glyphicon.glyphicon-cloud-download
-
+:javascript
+  $(function() {
+    $('#versionsTable').dataTable({
+      dom: 'C<"clear">lfrtip',
+      "order": [[0, "desc"]]
+    });
+  });
 

--- a/lib/oxidized/web/views/conf_search.haml
+++ b/lib/oxidized/web/views/conf_search.haml
@@ -3,7 +3,7 @@
     %h4
       %a{href: url_for('/nodes')} nodes
       \/ Nodes that contain 
-      %span " #{@to_research} "
+      %span "#{@to_research}"
   
 .row
   .refresh-div
@@ -17,14 +17,14 @@
         %th Configuration
 
     %tbody
-      -trclass = %w(even odd)
       - @nodes_match.each do |x|
         %tr
+          %td #{x[:node]}
           %td
-            #{x[:node]}
-          %td
-            %a{title: 'configuration', href: url_for("/node/fetch/#{x[:full_name]}")}
+            %a{title: 'configuration',
+               href: url_for("/node/fetch/#{x[:full_name]}")}
               %span.glyphicon.glyphicon-cloud-download
+
 :javascript
   $(function() {
     $('#versionsTable').dataTable({

--- a/lib/oxidized/web/views/conf_search.haml
+++ b/lib/oxidized/web/views/conf_search.haml
@@ -8,14 +8,14 @@
 .row.tbl-header
   .col-xs-12
     %h4
-      %a{:href=>url_for('/nodes')} nodes
+      %a{href: url_for('/nodes')} nodes
       \/ Nodes that contain 
       %span " #{@to_research} "
   
 .row
   .refresh-div
     %form
-      %button.ColVis_Button{:type => "button", :onclick => "history.go();"}
+      %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
         %span.glyphicon.glyphicon-repeat Refresh
   %table.table.table-responsive.tablesorter#versionsTable
     %thead
@@ -30,7 +30,7 @@
           %td
             #{x[:node]}
           %td
-            %a{:title => "configuration", :href => url_for("/node/fetch/#{x[:full_name]}") }
+            %a{title: 'configuration', href: url_for("/node/fetch/#{x[:full_name]}")}
               %span.glyphicon.glyphicon-cloud-download
 
 

--- a/lib/oxidized/web/views/default.haml
+++ b/lib/oxidized/web/views/default.haml
@@ -2,7 +2,7 @@
   !=haml :head
   %body
     =@data
-    %script{:src=>url_for('/scripts/jquery-2.1.1.min.js')}
-    %script{:src=>url_for('/scripts/jquery.dataTables.min.js')}
-    %script{:src=>url_for('/scripts/dataTables.bootstrap.js')}
-    %script{:src=>url_for('/scripts/dataTables.colVis.js')}
+    %script{src: url_for('/scripts/jquery-2.1.1.min.js')}
+    %script{src: url_for('/scripts/jquery.dataTables.min.js')}
+    %script{src: url_for('/scripts/dataTables.bootstrap.js')}
+    %script{src: url_for('/scripts/dataTables.colVis.js')}

--- a/lib/oxidized/web/views/default.haml
+++ b/lib/oxidized/web/views/default.haml
@@ -2,7 +2,3 @@
   !=haml :head
   %body
     =@data
-    %script{src: url_for('/scripts/jquery-2.1.1.min.js')}
-    %script{src: url_for('/scripts/jquery.dataTables.min.js')}
-    %script{src: url_for('/scripts/dataTables.bootstrap.js')}
-    %script{src: url_for('/scripts/dataTables.colVis.js')}

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -6,18 +6,18 @@
     - node_full = "#{@info[:node]}"
   %a{:href=>url_for("/node/version?node_full=#{node_full}")} versions
   \/ Diff version #{@info[:num]} - #{@info[:num2]} for Node 
-  %span{:class=>'node_title'} #{@info[:node]}
+  %span.node_title #{@info[:node]}
 - date_version = Time.parse @info[:date]
 Date of version:
 %span.time #{date_version.strftime("%d-%m-%y at %r")}
 %br
 Number of lines changed: 
-%span{:class=>'added'}added #{@stat[0]} 
-%span{:class=>'deleted'}removed #{@stat[1]}
+%span.added added #{@stat[0]} 
+%span.deleted removed #{@stat[1]}
 %br
 %br
 %form{ :action => "/node/version/diffs?node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}&date=#{@info[:date]}&num=#{@info[:num]}", :method => "post"}
-  %select{:name => "oid2", :id => "oid2"}
+  %select#oid2{:name => "oid2"}
     - diff2 = {}
     - num = @oids_dates.count + 1
     - next_id = false
@@ -32,37 +32,37 @@ Number of lines changed:
         
   %input{:type => "submit", :value => "Get diffs !"}
 %br
-%div{:class=>'old_version_title'} Version #{diff2[:num]} (#{time_from_now diff2[:date]})
-%div{:class=>'new_version_title'} Version #{@info[:num]} (#{time_from_now @info[:date]})
+.old_version_title Version #{diff2[:num]} (#{time_from_now diff2[:date]})
+.new_version_title Version #{@info[:num]} (#{time_from_now @info[:date]})
 %br
-%div{:class=>'diffs_old', :id=>'Test'}
+.diffs_old#Test
   - @diff[:old_diff].each do |line|
     - if /^\+.*/.match(line)
-      %div{:class=>'added',:id=>'Test'}> #{line}
+      .added#Test> #{line}
       
     - elsif /^\-.*/.match(line)
-      %div{:class=>'deleted'}> #{line}
+      .deleted> #{line}
       
     - elsif /^@@\s.*@@.*$/.match(line)
-      %div{:class=>'diff-index', :id=>'Test'}> #{line}
+      .diff-index#Test> #{line}
     - elsif /^empty_line&nbsp;/.match(line)
       - line.slice! "empty_line"
-      %div{:class=>'diff-empty'}> #{line}
+      .diff-empty> #{line}
     - else
       %div> #{line}
-%div{:class=>'diffs_new'}
+.diffs_new
   -  @diff[:new_diff].each do |line|
     - if /^\+.*/.match(line)
-      %div{:class=>'added'}> #{line}
+      .added> #{line}
     
     - elsif /^\-.*/.match(line)
-      %div{:class=>'deleted'}> #{line}
+      .deleted> #{line}
     
     - elsif /^@@\s.*@@.*$/.match(line)
-      %div{:class=>'diff-index'}> #{line}
+      .diff-index> #{line}
     - elsif /^empty_line&nbsp;/.match(line)
       - line.slice! "empty_line"
-      %div{:class=>'diff-empty'}> #{line}
+      .diff-empty> #{line}
     - else
       %div> #{line}
 %script{:src=>url_for('/scripts/jquery-2.1.1.min.js')}

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -4,7 +4,7 @@
     - node_full = "#{@info[:group] + '/' + @info[:node]}"
   - else
     - node_full = "#{@info[:node]}"
-  %a{:href=>url_for("/node/version?node_full=#{node_full}")} versions
+  %a{href: url_for("/node/version?node_full=#{node_full}")} versions
   \/ Diff version #{@info[:num]} - #{@info[:num2]} for Node 
   %span.node_title #{@info[:node]}
 - date_version = Time.parse @info[:date]
@@ -16,21 +16,23 @@ Number of lines changed:
 %span.deleted removed #{@stat[1]}
 %br
 %br
-%form{ :action => "/node/version/diffs?node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}&date=#{@info[:date]}&num=#{@info[:num]}", :method => "post"}
-  %select#oid2{:name => "oid2"}
+- params = "node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}"
+- params = "&date=#{@info[:date]}&num=#{@info[:num]}"
+%form{action: "/node/version/diffs?#{params}", method: 'post'}
+  %select#oid2{name: 'oid2'}
     - diff2 = {}
     - num = @oids_dates.count + 1
     - next_id = false
     - @oids_dates.each do |x|
-      %option{:value => x[:oid]} Version #{num -= 1} (#{time_from_now x[:date]})
+      %option{value: x[:oid]} Version #{num -= 1} (#{time_from_now x[:date]})
       - if (x[:oid].to_s == @info[:oid2]) || (next_id)
-        - diff2 = {:num => num, :date => x[:date]}
+        - diff2 = {num: num, date: x[:date]}
         - next_id = false
       - elsif (x[:oid].to_s == @info[:oid]) && !(@info[:oid2])
         - next_id = true
       
         
-  %input{:type => "submit", :value => "Get diffs !"}
+  %input{type: 'submit', value: 'Get diffs !'}
 %br
 .old_version_title Version #{diff2[:num]} (#{time_from_now diff2[:date]})
 .new_version_title Version #{@info[:num]} (#{time_from_now @info[:date]})

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -1,7 +1,6 @@
 %h4
-  - node_full = ''
   - if @info[:group] != ''
-    - node_full = "#{@info[:group] + '/' + @info[:node]}"
+    - node_full = "#{@info[:group]}/#{@info[:node]}"
   - else
     - node_full = "#{@info[:node]}"
   %a{href: url_for("/node/version?node_full=#{node_full}")} versions
@@ -17,7 +16,7 @@ Number of lines changed:
 %br
 %br
 - params = "node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}"
-- params = "&date=#{@info[:date]}&num=#{@info[:num]}"
+- params = "#{params}&date=#{@info[:date]}&num=#{@info[:num]}"
 %form{action: "/node/version/diffs?#{params}", method: 'post'}
   %select#oid2{name: 'oid2'}
     - diff2 = {}
@@ -30,9 +29,8 @@ Number of lines changed:
         - next_id = false
       - elsif (x[:oid].to_s == @info[:oid]) && !(@info[:oid2])
         - next_id = true
-      
-        
-  %input{type: 'submit', value: 'Get diffs !'}
+
+  %input{type: 'submit', value: 'Get diffs!'}
 %br
 .old_version_title Version #{diff2[:num]} (#{time_from_now diff2[:date]})
 .new_version_title Version #{@info[:num]} (#{time_from_now @info[:date]})
@@ -47,13 +45,16 @@ Number of lines changed:
       
     - elsif /^@@\s.*@@.*$/.match(line)
       .diff-index#Test> #{line}
+
     - elsif /^empty_line&nbsp;/.match(line)
       - line.slice! "empty_line"
       .diff-empty> #{line}
+
     - else
       %div> #{line}
+
 .diffs_new
-  -  @diff[:new_diff].each do |line|
+  - @diff[:new_diff].each do |line|
     - if /^\+.*/.match(line)
       .added> #{line}
     
@@ -62,8 +63,11 @@ Number of lines changed:
     
     - elsif /^@@\s.*@@.*$/.match(line)
       .diff-index> #{line}
+
     - elsif /^empty_line&nbsp;/.match(line)
       - line.slice! "empty_line"
       .diff-empty> #{line}
+
     - else
       %div> #{line}
+

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -67,4 +67,3 @@ Number of lines changed:
       .diff-empty> #{line}
     - else
       %div> #{line}
-%script{:src=>url_for('/scripts/jquery-2.1.1.min.js')}

--- a/lib/oxidized/web/views/head.haml
+++ b/lib/oxidized/web/views/head.haml
@@ -5,4 +5,4 @@
   %link{rel: 'shortcut icon', href: url_for('/images/favicon.ico')}
   %link{rel: 'stylesheet', href: url_for('/css/dataTables.bootstrap.css')}
   %link{rel: 'stylesheet', href: url_for('/css/dataTables.colVis.css')}
-
+  %script{src: url_for('/scripts/jquery-2.1.1.min.js')}

--- a/lib/oxidized/web/views/head.haml
+++ b/lib/oxidized/web/views/head.haml
@@ -1,8 +1,8 @@
 %head
   %title oxidized
-  %link{:rel=>'stylesheet', :href=>url_for('/css/bootstrap.min.css')}
-  %link{:rel=>'stylesheet', :href=>url_for('/css/oxidized.css')}
-  %link{:rel=>'shortcut icon', :href=>url_for('/images/favicon.ico')}
-  %link{:rel=>'stylesheet', :href=>url_for('/css/dataTables.bootstrap.css')}
-  %link{:rel=>'stylesheet', :href=>url_for('/css/dataTables.colVis.css')}
+  %link{rel: 'stylesheet', href: url_for('/css/bootstrap.min.css')}
+  %link{rel: 'stylesheet', href: url_for('/css/oxidized.css')}
+  %link{rel: 'shortcut icon', href: url_for('/images/favicon.ico')}
+  %link{rel: 'stylesheet', href: url_for('/css/dataTables.bootstrap.css')}
+  %link{rel: 'stylesheet', href: url_for('/css/dataTables.colVis.css')}
 

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -27,7 +27,6 @@
                   %span.glyphicon.glyphicon-search
     .container
       =yield
-    %script{src: url_for('/scripts/jquery-2.1.1.min.js')}
     %script{src: url_for('/scripts/jquery.dataTables.min.js')}
     %script{src: url_for('/scripts/dataTables.bootstrap.js')}
     %script{src: url_for('/scripts/dataTables.colVis.js')}

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -5,23 +5,26 @@
       .container
         .navbar-header
           .collapse.navbar-collapse
-	    %ul.nav.navbar-nav
-	      %li
+            %ul.nav.navbar-nav
+              %li
                 %a.navbar-brand{href: url_for('/')}
                   %img{src: url_for('/images/oxidizing_40px.png')} Oxidized
+
               %li{class: request.path_info == '/nodes/stats' ? 'active' : ''}
                 %a.navbar-link{href: url_for('/nodes/stats')} Stats
-	      %li
-	        %a.navbar-link{href: url_for('/migration')} Migration
+
+              %li
+                %a.navbar-link{href: url_for('/migration')} Migration
+
             %form.navbar-form.navbar-right{role: 'search',
-	                                   action: '/nodes/conf_search',
-					   method: 'post'}
-	      .form-group#to_search_in_config{name: 'to_search_in_config'}
-	        %input.form-control.input-sm{type: 'text',
-		                             name: 'search_in_conf_textbox',
-		                             placeholder: 'Search in Configs'}
-		%button.btn.btn-primary{type: 'submit'}
-		  %span.glyphicon.glyphicon-search
+                                           action: '/nodes/conf_search',
+                                           method: 'post'}
+              .form-group#to_search_in_config{name: 'to_search_in_config'}
+                %input.form-control.input-sm{type: 'text',
+                                             name: 'search_in_conf_textbox',
+                                             placeholder: 'Search in Configs'}
+                %button.btn.btn-primary{type: 'submit'}
+                  %span.glyphicon.glyphicon-search
     .container
       =yield
     %script{src: url_for('/scripts/jquery-2.1.1.min.js')}

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -1,27 +1,27 @@
 %html
   !=haml :head
   %body
-    %header.navbar.navbar-static-top.ox-nav{:role=>'navigation'}
+    %header.navbar.navbar-static-top.ox-nav{role: 'navigation'}
       .container
         .navbar-header
           .collapse.navbar-collapse
 	    %ul.nav.navbar-nav
 	      %li
-                %a.navbar-brand{:href=>url_for('/')}
-                  %img{:src=>url_for('/images/oxidizing_40px.png')} Oxidized
-              %li{:class=>request.path_info == '/nodes/stats' ? 'active' : ''}
-                %a.navbar-link{:href=>url_for('/nodes/stats')} Stats
+                %a.navbar-brand{href: url_for('/')}
+                  %img{src: url_for('/images/oxidizing_40px.png')} Oxidized
+              %li{class: request.path_info == '/nodes/stats' ? 'active' : ''}
+                %a.navbar-link{href: url_for('/nodes/stats')} Stats
 	      %li
-	        %a.navbar-link{:href=>url_for('/migration')} Migration
-            %form.navbar-form.navbar-right{:role=>'search',
-	                                   :action => "/nodes/conf_search",
-					   :method => "post"}
-	      .form-group#to_search_in_config{:name => "to_search_in_config"}
-	        %input.form-control.input-sm{:type => "text",
-		                             :name => "search_in_conf_textbox",
-		                             :placeholder=>'Search in Configs'}
-		%button.btn.btn-primary{:type => "submit"}
+	        %a.navbar-link{href: url_for('/migration')} Migration
+            %form.navbar-form.navbar-right{role: 'search',
+	                                   action: '/nodes/conf_search',
+					   method: 'post'}
+	      .form-group#to_search_in_config{name: 'to_search_in_config'}
+	        %input.form-control.input-sm{type: 'text',
+		                             name: 'search_in_conf_textbox',
+		                             placeholder: 'Search in Configs'}
+		%button.btn.btn-primary{type: 'submit'}
 		  %span.glyphicon.glyphicon-search
     .container
       =yield
-    %script{:src=>url_for('/scripts/oxidized.js')}
+    %script{src: url_for('/scripts/oxidized.js')}

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -24,4 +24,8 @@
 		  %span.glyphicon.glyphicon-search
     .container
       =yield
+    %script{src: url_for('/scripts/jquery-2.1.1.min.js')}
+    %script{src: url_for('/scripts/jquery.dataTables.min.js')}
+    %script{src: url_for('/scripts/dataTables.bootstrap.js')}
+    %script{src: url_for('/scripts/dataTables.colVis.js')}
     %script{src: url_for('/scripts/oxidized.js')}

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -1,27 +1,27 @@
 %html
   !=haml :head
   %body
-    %header{:class=>'navbar navbar-static-top ox-nav', :role=>'navigation'}
-      %div{:class=>'container'}
-        %div{:class=>'navbar-header'}
-          %div{:class=>'collapse navbar-collapse'}
-	    %ul{:class=>'nav navbar-nav'}
+    %header.navbar.navbar-static-top.ox-nav{:role=>'navigation'}
+      .container
+        .navbar-header
+          .collapse.navbar-collapse
+	    %ul.nav.navbar-nav
 	      %li
-                %a{:class=>'navbar-brand', :href=>url_for('/')}
+                %a.navbar-brand{:href=>url_for('/')}
                   %img{:src=>url_for('/images/oxidizing_40px.png')} Oxidized
               %li{:class=>request.path_info == '/nodes/stats' ? 'active' : ''}
-                %a{:class=>'navbar-link', :href=>url_for('/nodes/stats')} Stats
+                %a.navbar-link{:href=>url_for('/nodes/stats')} Stats
 	      %li
-	        %a{:class=>'navbar-link', :href=>url_for('/migration')} Migration
-            %form{:class=>'navbar-form navbar-right', :role=>'search',
-	          :action => "/nodes/conf_search", :method => "post"}
-	      %div{:class=>'form-group', :name => "to_search_in_config",
-	           :id => "to_search_in_config"}
-	        %input{:class=>'form-control input-sm', :type => "text",
-		       :name => "search_in_conf_textbox",
-		       :placeholder=>'Search in Configs'}
-		%button{:class=>'btn btn-primary', :type => "submit"}
-		  %span{:class=>'glyphicon glyphicon-search'}
-    %div{:class=>'container'}
+	        %a.navbar-link{:href=>url_for('/migration')} Migration
+            %form.navbar-form.navbar-right{:role=>'search',
+	                                   :action => "/nodes/conf_search",
+					   :method => "post"}
+	      .form-group#to_search_in_config{:name => "to_search_in_config"}
+	        %input.form-control.input-sm{:type => "text",
+		                             :name => "search_in_conf_textbox",
+		                             :placeholder=>'Search in Configs'}
+		%button.btn.btn-primary{:type => "submit"}
+		  %span.glyphicon.glyphicon-search
+    .container
       =yield
     %script{:src=>url_for('/scripts/oxidized.js')}

--- a/lib/oxidized/web/views/migration.haml
+++ b/lib/oxidized/web/views/migration.haml
@@ -1,19 +1,25 @@
 %span.migration_span
   Here you can migrate from your Rancid to Oxidized.
   %br
-  To do it, just execute te following actions :
+  To do it, just execute the following actions:
 %br
 %br
 %form{method: 'post', enctype: 'multipart/form-data'}
-  %label{for: 'path_new_file'} Set the path for your future equipement file in .db format
+  %label{for: 'path_new_file'}
+    Set the path for your future equipement file in .db format.
   %br
   %input{type: 'text', name: 'path_new_file', value: 'Path/to_file/here.db'}
   %br
   %br
-  %label{for: 'cloginrc'} Select your .cloginrc file, must be readeable
+  %label{for: 'cloginrc'}
+    Select your .cloginrc file.
+    It must be readeable by Oxidized.
   %input{type: 'file', name: 'cloginrc'}
   %br
-  %label{for: 'files'} Select all your router.db fies of rancid, and add their group (Click "Add file" if you have multiple files)
+  %label{for: 'files'}
+    Select all of your router.db files for rancid.
+    Add their groups.
+    Click "Add file" if you have multiple files.
   %table#files{name: 'files'}
     %th#file Group
     %th#file File
@@ -29,8 +35,8 @@
   %br
   %label{for: 'upload_button'} Then Click "Migrate" to do your migration
   %br
-  %input#upload_button{type: 'submit', value: 'Migrate !'}
+  %input#upload_button{type: 'submit', value: 'Migrate!'}
   /
     used to know the numbers of files router.db
-  %input#number{type: 'hidden', value: '1', name: 'number')
+  %input#number{type: 'hidden', value: '1', name: 'number'}
 %script{src: url_for('/scripts/script-migration.js')}

--- a/lib/oxidized/web/views/migration.haml
+++ b/lib/oxidized/web/views/migration.haml
@@ -4,33 +4,33 @@
   To do it, just execute te following actions :
 %br
 %br
-%form(method="post" enctype="multipart/form-data")
-  %label{:for=>"path_new_file"} Set the path for your future equipement file in .db format
+%form{method: 'post', enctype: 'multipart/form-data'}
+  %label{for: 'path_new_file'} Set the path for your future equipement file in .db format
   %br
-  %input{:type=>"text", :name=>"path_new_file", :value=>"Path/to_file/here.db"}
+  %input{type: 'text', name: 'path_new_file', value: 'Path/to_file/here.db'}
   %br
   %br
-  %label{:for=>"cloginrc"} Select your .cloginrc file, must be readeable
-  %input{:type=>"file", :name=>"cloginrc"}
+  %label{for: 'cloginrc'} Select your .cloginrc file, must be readeable
+  %input{type: 'file', name: 'cloginrc'}
   %br
-  %label{:for=>"files"} Select all your router.db fies of rancid, and add their group (Click "Add file" if you have multiple files)
-  %table#files{:name=>"files"}
+  %label{for: 'files'} Select all your router.db fies of rancid, and add their group (Click "Add file" if you have multiple files)
+  %table#files{name: 'files'}
     %th#file Group
     %th#file File
     %tbody
       %tr
         %td#file
-          %input{:type=>"text", :name=>"group1", :value=>"default"}
+          %input{type: 'text', name: 'group1', value: 'default'}
         %td#file
-          %input{:type=>"file", :name=>"file1", :required=>""}
+          %input{type: 'file', name: 'file1', required: ''}
   %br
-  %input(type='button' value ='Add file' onclick="add_file_upload();")
+  %input{type: 'button', value: 'Add file', onclick: 'add_file_upload();'}
   %br
   %br
-  %label{:for=>"upload_button"}Then Click "Migrate" to do your migration
+  %label{for: 'upload_button'} Then Click "Migrate" to do your migration
   %br
-  %input#upload_button(type='submit' value='Migrate !')
+  %input#upload_button{type: 'submit', value: 'Migrate !'}
   /
     used to know the numbers of files router.db
-  %input#number(type='hidden' value='1' name='number')
-%script{:src=>url_for('/scripts/script-migration.js')}
+  %input#number{type: 'hidden', value: '1', name: 'number')
+%script{src: url_for('/scripts/script-migration.js')}

--- a/lib/oxidized/web/views/migration.haml
+++ b/lib/oxidized/web/views/migration.haml
@@ -1,41 +1,36 @@
-!=haml :head
+%span.migration_span
+  Here you can migrate from your Rancid to Oxidized.
+  %br
+  To do it, just execute te following actions :
+%br
+%br
+%form(method="post" enctype="multipart/form-data")
+  %label{:for=>"path_new_file"} Set the path for your future equipement file in .db format
+  %br
+  %input{:type=>"text", :name=>"path_new_file", :value=>"Path/to_file/here.db"}
+  %br
+  %br
+  %label{:for=>"cloginrc"} Select your .cloginrc file, must be readeable
+  %input{:type=>"file", :name=>"cloginrc"}
+  %br
+  %label{:for=>"files"} Select all your router.db fies of rancid, and add their group (Click "Add file" if you have multiple files)
+  %table#files{:name=>"files"}
+    %th#file Group
+    %th#file File
+    %tbody
+      %tr
+        %td#file
+          %input{:type=>"text", :name=>"group1", :value=>"default"}
+        %td#file
+          %input{:type=>"file", :name=>"file1", :required=>""}
+  %br
+  %input(type='button' value ='Add file' onclick="add_file_upload();")
+  %br
+  %br
+  %label{:for=>"upload_button"}Then Click "Migrate" to do your migration
+  %br
+  %input#upload_button(type='submit' value='Migrate !')
+  /
+    used to know the numbers of files router.db
+  %input#number(type='hidden' value='1' name='number')
 %script{:src=>url_for('/scripts/script-migration.js')}
-%body
-  
-  %span{:id=>"migration_span"}
-    Here you can migrate from your Rancid to Oxidized.
-    %br
-    To do it, just execute te following actions :
-  %br
-  %br
-  %form(method="post" enctype="multipart/form-data")
-    %label{:for=>"path_new_file"} Set the path for your future equipement file in .db format
-    %br
-    %input{:type=>"text", :name=>"path_new_file", :value=>"Path/to_file/here.db"}
-    %br
-    %br
-    %label{:for=>"cloginrc"} Select your .cloginrc file, must be readeable
-    %input{:type=>"file", :name=>"cloginrc"}
-    %br
-    %label{:for=>"files"} Select all your router.db fies of rancid, and add their group (Click "Add file" if you have multiple files)
-    %table{:id=>"files", :name=>"files"}
-      %th{:id=>"file"} Group
-      %th{:id=>"file"} File
-      %tbody
-        %tr
-          %td{:id=>"file"}
-            %input{:type=>"text", :name=>"group1", :value=>"default"}
-          %td{:id=>"file"}
-            %input{:type=>"file", :name=>"file1", :required=>""}
-    %br
-    %input(type='button' value ='Add file' onclick="add_file_upload();")
-    %br
-    %br
-    %label{:for=>"upload_button"}Then Click "Migrate" to do your migration
-    %br
-    %input(type='submit' value='Migrate !' id="upload_button")
-    /
-      used to know the numbers of files router.db
-    %input(type='hidden' value='1' id='number' name='number')
-    
-  

--- a/lib/oxidized/web/views/node.haml
+++ b/lib/oxidized/web/views/node.haml
@@ -7,7 +7,8 @@
     &nbsp;
     %a{title: 'configuration', href: url_for("/node/fetch/#{@data[:full_name]}")}
       %span.glyphicon.glyphicon-cloud-download{style: 'color: #000; font-size: 14px;'}
-    %a{title: 'versions', href: url_for("/node/version?node_full=#{@data[:full_name]}")}
+    %a{title: 'versions',
+       href: url_for("/node/version?node_full=#{@data[:full_name]}")}
       %img{src: url_for('/images/versioning_18px.png')}
     %a{title: 'update', href: url_for("/node/next/#{@data[:full_name]}")}
       %span.glyphicon.glyphicon-repeat{style: 'color: #000; font-size: 14px;'}

--- a/lib/oxidized/web/views/node.haml
+++ b/lib/oxidized/web/views/node.haml
@@ -1,16 +1,16 @@
 !=haml :head
 %body
   %h4
-    %a{:href=>url_for('/nodes')} nodes
+    %a{href: url_for('/nodes')} nodes
     %span /
     =@data[:name]
     &nbsp;
-    %a{:title => "configuration", :href => url_for("/node/fetch/#{@data[:full_name]}") }
-      %span.glyphicon.glyphicon-cloud-download{:style => "color: #000; font-size: 14px;"}
-    %a{:title => "versions", :href => url_for("/node/version?node_full=#{@data[:full_name]}") }
-      %img{:src=>url_for('/images/versioning_18px.png')}
-    %a{:title => "update", :href => url_for("/node/next/#{@data[:full_name]}") }
-      %span.glyphicon.glyphicon-repeat{:style => "color: #000; font-size: 14px;"}
+    %a{title: 'configuration', href: url_for("/node/fetch/#{@data[:full_name]}")}
+      %span.glyphicon.glyphicon-cloud-download{style: 'color: #000; font-size: 14px;'}
+    %a{title: 'versions', href: url_for("/node/version?node_full=#{@data[:full_name]}")}
+      %img{src: url_for('/images/versioning_18px.png')}
+    %a{title: 'update', href: url_for("/node/next/#{@data[:full_name]}")}
+      %span.glyphicon.glyphicon-repeat{style: 'color: #000; font-size: 14px;'}
   -out='';PP.pp(@data,out)
   %pre
     = preserve "#{out}"

--- a/lib/oxidized/web/views/node.haml
+++ b/lib/oxidized/web/views/node.haml
@@ -6,11 +6,11 @@
     =@data[:name]
     &nbsp;
     %a{:title => "configuration", :href => url_for("/node/fetch/#{@data[:full_name]}") }
-      %span{:class=>'glyphicon glyphicon-cloud-download', :style => "color: #000; font-size: 14px;"}
+      %span.glyphicon.glyphicon-cloud-download{:style => "color: #000; font-size: 14px;"}
     %a{:title => "versions", :href => url_for("/node/version?node_full=#{@data[:full_name]}") }
       %img{:src=>url_for('/images/versioning_18px.png')}
     %a{:title => "update", :href => url_for("/node/next/#{@data[:full_name]}") }
-      %span{:class=>'glyphicon glyphicon-repeat', :style => "color: #000; font-size: 14px;"}
+      %span.glyphicon.glyphicon-repeat{:style => "color: #000; font-size: 14px;"}
   -out='';PP.pp(@data,out)
   %pre
     = preserve "#{out}"

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -1,17 +1,3 @@
-:javascript
-  $(function() {
-    $('#nodesTable').dataTable({
-      dom: 'C<"clear">lfrtip',
-      "lengthMenu": [[50, 250, 500, -1], [50, 250, 500, "All"]],
-      columnDefs: [
-        { visible: false, targets: 1 },
-        {type: "string", targets: 3}
-      ],
-      colVis: {
-            exclude: [ 0, 5 ]
-        }
-    });
-  });
 .row.tbl-header
   .col-xs-12.col-md-2
     %h4 nodes /
@@ -56,3 +42,21 @@
             &nbsp;&nbsp;
             %a{title: 'update', href: url_for("/node/next/#{node[:full_name]}")}
               %span.glyphicon.glyphicon-repeat
+:javascript
+  $(function() {
+    $('#nodesTable').dataTable({
+      dom: 'C<"clear">lfrtip',
+      "lengthMenu": [[50, 250, 500, -1], [50, 250, 500, "All"]],
+      columnDefs: [{
+        visible: false,
+        targets: 1
+      }, {
+        type: "string",
+        targets: 3
+      }],
+      colVis: {
+        exclude: [0, 5]
+      }
+    });
+  });
+

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -6,8 +6,8 @@
   .refresh-div
     %form
       %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
-        %span.glyphicon.glyphicon-repeat
-        Refresh
+        %span.glyphicon.glyphicon-repeat Refresh
+
   %table.table.table-responsive.tablesorter#nodesTable
     %thead
       %tr
@@ -20,9 +20,9 @@
         %th Actions
 
     %tbody
-      -trclass = %w(even odd)
-      -@data.sort_by{|e|e[:name]}.each do |node|
-        -klass = trclass.rotate!.first
+      - trclass = %w(even odd)
+      - @data.sort_by{|e|e[:name]}.each do |node|
+        - klass = trclass.rotate!.first
         %tr{class: "#{klass} ox-status-#{node[:status]}"}
           %td
             %a{href: url_for("/node/show/#{node[:name]}")} #{node[:name]}
@@ -34,14 +34,17 @@
               %span{style: 'visibility: hidden'}#{node[:status]}
           %td.time= node[:time]
           %td
-            %a{title: 'configuration', href: url_for("/node/fetch/#{node[:full_name]}")}
+            %a{title: 'configuration',
+               href: url_for("/node/fetch/#{node[:full_name]}")}
               %span.glyphicon.glyphicon-cloud-download
             &nbsp;&nbsp;
-            %a{title: 'versions', href: url_for("/node/version?node_full=#{node[:full_name]}")}
+            %a{title: 'versions',
+               href: url_for("/node/version?node_full=#{node[:full_name]}")}
               %img{src: url_for('/images/versioning_18px.png')}
             &nbsp;&nbsp;
             %a{title: 'update', href: url_for("/node/next/#{node[:full_name]}")}
               %span.glyphicon.glyphicon-repeat
+
 :javascript
   $(function() {
     $('#nodesTable').dataTable({

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -12,17 +12,17 @@
         }
     });
   });
-%div{:class=>'row tbl-header'}
-  %div{:class=>'col-xs-12 col-md-2'}
+.row.tbl-header
+  .col-xs-12.col-md-2
     %h4 nodes /
   
-%div{:class=>'row'}
-  %div{:class=>'refresh-div'}
+.row
+  .refresh-div
     %form
-      %button{:class => "ColVis_Button", :type => "button", :onclick => "history.go();"}
-        %span{:class=>"glyphicon glyphicon-repeat"}
+      %button.ColVis_Button{:type => "button", :onclick => "history.go();"}
+        %span.glyphicon.glyphicon-repeat
         Refresh
-  %table{:id=>'nodesTable', :class=>'table table-responsive tablesorter'}
+  %table.table.table-responsive.tablesorter#nodesTable
     %thead
       %tr
         %th Name
@@ -46,13 +46,13 @@
           %td
             %div{:title=>node[:status], :class=>node[:status]}
               %span{:style=>'visibility: hidden'}#{node[:status]}
-          %td{:class=>'time'}= node[:time]
+          %td.time= node[:time]
           %td
             %a{:title => "configuration", :href => url_for("/node/fetch/#{node[:full_name]}") }
-              %span{:class=>'glyphicon glyphicon-cloud-download'}
+              %span.glyphicon.glyphicon-cloud-download
             &nbsp;&nbsp;
             %a{:title => "versions", :href => url_for("/node/version?node_full=#{node[:full_name]}") }
               %img{:src=>url_for('/images/versioning_18px.png')}
             &nbsp;&nbsp;
             %a{:title => "update", :href => url_for("/node/next/#{node[:full_name]}") }
-              %span{:class=>'glyphicon glyphicon-repeat'}
+              %span.glyphicon.glyphicon-repeat

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -19,7 +19,7 @@
 .row
   .refresh-div
     %form
-      %button.ColVis_Button{:type => "button", :onclick => "history.go();"}
+      %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
         %span.glyphicon.glyphicon-repeat
         Refresh
   %table.table.table-responsive.tablesorter#nodesTable
@@ -37,22 +37,22 @@
       -trclass = %w(even odd)
       -@data.sort_by{|e|e[:name]}.each do |node|
         -klass = trclass.rotate!.first
-        %tr{:class=>"#{klass} ox-status-#{node[:status]}"}
+        %tr{class: "#{klass} ox-status-#{node[:status]}"}
           %td
-            %a{:href => url_for("/node/show/#{node[:name]}") } #{node[:name]}
+            %a{href: url_for("/node/show/#{node[:name]}")} #{node[:name]}
           %td= node[:ip]
           %td= node[:model]
           %td= node[:group]
           %td
-            %div{:title=>node[:status], :class=>node[:status]}
-              %span{:style=>'visibility: hidden'}#{node[:status]}
+            %div{title: node[:status], class: node[:status]}
+              %span{style: 'visibility: hidden'}#{node[:status]}
           %td.time= node[:time]
           %td
-            %a{:title => "configuration", :href => url_for("/node/fetch/#{node[:full_name]}") }
+            %a{title: 'configuration', href: url_for("/node/fetch/#{node[:full_name]}")}
               %span.glyphicon.glyphicon-cloud-download
             &nbsp;&nbsp;
-            %a{:title => "versions", :href => url_for("/node/version?node_full=#{node[:full_name]}") }
-              %img{:src=>url_for('/images/versioning_18px.png')}
+            %a{title: 'versions', href: url_for("/node/version?node_full=#{node[:full_name]}")}
+              %img{src: url_for('/images/versioning_18px.png')}
             &nbsp;&nbsp;
-            %a{:title => "update", :href => url_for("/node/next/#{node[:full_name]}") }
+            %a{title: 'update', href: url_for("/node/next/#{node[:full_name]}")}
               %span.glyphicon.glyphicon-repeat

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -5,28 +5,79 @@
       \/ stats
 
 .row
-  %table.table.table-responsive.tablesorter#versionsTable
+  %table.table.table-responsive.table-condensed.table-striped.table-hover.tablesorter#versionsTable
     %caption
-      %span Failures in Previous 24 Hours
-      %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
-        %span.glyphicon.glyphicon-repeat Refresh
+      %span Node Statistics
+      %button.btn.btn-default.pull-right{type: 'button', onclick: 'history.go();'}
+        %span.glyphicon.glyphicon-repeat
+        Refresh
 
     %thead
       %tr
         %th Name
-        %th Last Success
+        %th Total Runs
+        %th Total Failures
+        %th Failure Rate
+        %th Average Run Time
+        %th Last Status
+        %th Last Update
+        %th Last Failure
 
     %tbody
-      - @data.select do |node, stats|
-        - not stats[:success] or (stats[:success].last[:end] < Time.now.utc-60*60*24)
-      - end.map do |node, stats|
-        - last = stats[:success] ? last.last[:end] : 'never'
-        %tr
-          %td= node
-          %td= last
+      - @data.map do |node, stats|
+        - status = 'no_connection'
+        - successes = 0
+        - failures = 0
+        - avg_success_time = 0
+        - avg_failure_time = 0
+        - avg_time = 0
+        - row_class = ''
 
-:javascript
-  $(function(){
-    $("#statsTable").tablesorter();
-  });
+        - if stats[:success]
+          - last_success = stats[:success].last[:end]
+          - successes = stats[:success].length
+          - avg_success_time = stats[:success].inject do |sum, el|
+            - sum = sum.is_a?(Hash) ? sum[:time] : sum
+            - sum + el[:time]
+            - end / successes
+
+        - if stats[:no_connection]
+          - last_failure = stats[:no_connection].last[:end]
+          - failures = stats[:no_connection].length
+          - avg_failure_time = stats[:no_connection].inject do |sum, el|
+            - sum = sum.is_a?(Hash) ? sum[:time] : sum
+            - sum + el[:time]
+            - end / failures
+
+        - if avg_success_time > 0 && avg_failure_time > 0
+          - avg_time = (avg_success_time + avg_failure_time) / 2
+        - elsif avg_success_time > 0
+          - avg_time = avg_success_time
+        - elsif avg_failure_time > 0
+          - avg_time = avg_failure_time
+        - avg_time = "#{'%.2f' % avg_time}" unless avg_time == 'Unknown'
+
+        - if last_success && last_failure
+          - status = last_success > last_failure ? 'success' : 'no_connection'
+        - elsif last_success
+          - status = 'success'
+          - last_failure = 'Never'
+        - else
+          - last_success = 'Never'
+
+        - total_runs = successes + failures
+        - failure_rate = (failures / total_runs.to_f) * 100
+        - row_class = 'warning' if failure_rate >= 50
+        - row_class = 'danger' if failure_rate >= 75
+
+        %tr{class: row_class}
+          %td= node
+          %td= total_runs
+          %td= failures
+          %td #{'%.2f' % failure_rate}%
+          %td #{'%.2f' % avg_time}s
+          %td
+            %div{title: status, class: status}
+          %td.time= last_success
+          %td.time= last_failure
 

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -18,8 +18,7 @@
 
     %tbody
       - @data.select do |node, stats|
-        - unless stats[:success]
-        - if stats[:success].last[:end] < Time.now.utc-60*60*24
+        - not stats[:success] or (stats[:success].last[:end] < Time.now.utc-60*60*24)
       - end.map do |node, stats|
         - last = stats[:success] ? last.last[:end] : 'never'
         %tr

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -3,25 +3,29 @@
     %h4
       %a{href: url_for('/nodes')} nodes
       \/ stats
+
 .row
   %table.table.table-responsive.tablesorter#versionsTable
     %caption
       %span Failures in Previous 24 Hours
       %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
-        %span.glyphicon.glyphicon-repeat
-        Refresh
+        %span.glyphicon.glyphicon-repeat Refresh
+
     %thead
       %tr
         %th Name
         %th Last Success
+
     %tbody
       - @data.select do |node, stats|
-        - not stats[:success] or (stats[:success].last[:end] < Time.now.utc-60*60*24)
+        - unless stats[:success]
+        - if stats[:success].last[:end] < Time.now.utc-60*60*24
       - end.map do |node, stats|
         - last = stats[:success] ? last.last[:end] : 'never'
         %tr
           %td= node
           %td= last
+
 :javascript
   $(function(){
     $("#statsTable").tablesorter();

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -1,8 +1,8 @@
 %h4
   - if @info[:group] != ''
-    %a{:href=>url_for("/node/version?node_full=#{@info[:group] + '/' + @info[:node]}")} versions
+    %a{href: url_for("/node/version?node_full=#{@info[:group] + '/' + @info[:node]}")} versions
   - else    
-    %a{:href=>url_for("/node/version?node_full=#{@info[:node]}")} versions
+    %a{href: url_for("/node/version?node_full=#{@info[:node]}")} versions
   \/ version #{@info[:num]}  for Node 
   %span.node_title #{@info[:node]}
   
@@ -11,7 +11,7 @@ Date of version:
 %span.time #{date_version.strftime('%Y-%m-%d %H:%M:%S %Z')}
 %br
 %br
-%div{:class=>'diffs'}
+.diffs
   - @data.each_line do |line|
     %div> #{line}
-%script{:src=>url_for('/scripts/jquery-2.1.1.min.js')}
+%script{src: url_for('/scripts/jquery-2.1.1.min.js')}

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -14,4 +14,3 @@ Date of version:
 .diffs
   - @data.each_line do |line|
     %div> #{line}
-%script{src: url_for('/scripts/jquery-2.1.1.min.js')}

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -1,11 +1,12 @@
 %h4
   - if @info[:group] != ''
-    %a{href: url_for("/node/version?node_full=#{@info[:group] + '/' + @info[:node]}")} versions
-  - else    
-    %a{href: url_for("/node/version?node_full=#{@info[:node]}")} versions
-  \/ version #{@info[:num]}  for Node 
+    - params = "node_full=#{@info[:group] + '/' + @info[:node]}"
+  - else
+    - params = "node_full=#{@info[:node]}"
+  %a{href: url_for("/node/version?#{params}")} versions
+  \/ version #{@info[:num]} for Node
   %span.node_title #{@info[:node]}
-  
+
 - date_version = Time.parse @info[:date]
 Date of version: 
 %span.time #{date_version.strftime('%Y-%m-%d %H:%M:%S %Z')}

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -4,7 +4,7 @@
   - else    
     %a{:href=>url_for("/node/version?node_full=#{@info[:node]}")} versions
   \/ version #{@info[:num]}  for Node 
-  %span{:class=>'node_title'} #{@info[:node]}
+  %span.node_title #{@info[:node]}
   
 - date_version = Time.parse @info[:date]
 Date of version: 

--- a/lib/oxidized/web/views/versions.haml
+++ b/lib/oxidized/web/views/versions.haml
@@ -11,14 +11,14 @@
 .row.tbl-header
   .col-xs-12
     %h4
-      %a{:href=>url_for('/nodes')} nodes
+      %a{href: url_for('/nodes')} nodes
       \/ Versions for Node 
       %span.node_title #{@node}
   
 .row
   .refresh-div
     %form
-      %button.ColVis_Button{:type => "button", :onclick => "history.go();"}
+      %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
         %span.glyphicon.glyphicon-repeat
         Refresh
   %table.table.table-responsive.tablesorter#versionsTable
@@ -44,8 +44,9 @@
           %td
             #{x[:message]}
           %td
-            %a{:title => "configuration", :href => url_for("/node/version/view?node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}") }
+	    - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}"
+            %a{title: 'configuration', href: url_for("/node/version/view?#{params}")}
               %span.glyphicon.glyphicon-cloud-download
             &nbsp;&nbsp;
-            %a{:title => "diff", :href => url_for("/node/version/diffs?node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}") }
-              %img{:src=>url_for('/images/diff_15x17.png')}
+            %a{title: 'diff', href: url_for("/node/version/diffs?#{params}") }
+              %img{src: url_for('/images/diff_15x17.png')}

--- a/lib/oxidized/web/views/versions.haml
+++ b/lib/oxidized/web/views/versions.haml
@@ -1,13 +1,3 @@
-:javascript
-  $(function() {
-    $('#versionsTable').dataTable({
-      dom: 'C<"clear">lfrtip',
-      "order": [[ 0, "desc" ]],
-      columnDefs: [
-            { visible: false, targets: [2, 3] }
-        }
-    });
-  });
 .row.tbl-header
   .col-xs-12
     %h4
@@ -44,9 +34,20 @@
           %td
             #{x[:message]}
           %td
-	    - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}"
+            - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}"
             %a{title: 'configuration', href: url_for("/node/version/view?#{params}")}
               %span.glyphicon.glyphicon-cloud-download
             &nbsp;&nbsp;
             %a{title: 'diff', href: url_for("/node/version/diffs?#{params}") }
               %img{src: url_for('/images/diff_15x17.png')}
+:javascript
+  $(function() {
+    $('#versionsTable').dataTable({
+      dom: 'C<"clear">lfrtip',
+      "order": [[0, "desc"]],
+      columnDefs: [{
+        visible: false,
+        targets: [2, 3]
+      }]
+    });
+  });

--- a/lib/oxidized/web/views/versions.haml
+++ b/lib/oxidized/web/views/versions.haml
@@ -8,20 +8,20 @@
         }
     });
   });
-%div{:class=>'row tbl-header'}
-  %div{:class=>'col-xs-12 '}
+.row.tbl-header
+  .col-xs-12
     %h4
       %a{:href=>url_for('/nodes')} nodes
       \/ Versions for Node 
-      %span{:class=>'node_title'} #{@node}
+      %span.node_title #{@node}
   
-%div{:class=>'row'}
-  %div{:class=>'refresh-div'}
+.row
+  .refresh-div
     %form
-      %button{:class => "ColVis_Button", :type => "button", :onclick => "history.go();"}
-        %span{:class=>"glyphicon glyphicon-repeat"}
+      %button.ColVis_Button{:type => "button", :onclick => "history.go();"}
+        %span.glyphicon.glyphicon-repeat
         Refresh
-  %table{:id=>'versionsTable', :class=>'table table-responsive tablesorter'}
+  %table.table.table-responsive.tablesorter#versionsTable
     %thead
       %tr
         %th Version
@@ -45,10 +45,7 @@
             #{x[:message]}
           %td
             %a{:title => "configuration", :href => url_for("/node/version/view?node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}") }
-              %span{:class=>'glyphicon glyphicon-cloud-download'} 
+              %span.glyphicon.glyphicon-cloud-download
             &nbsp;&nbsp;
             %a{:title => "diff", :href => url_for("/node/version/diffs?node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}") }
               %img{:src=>url_for('/images/diff_15x17.png')}
-          
-
-    

--- a/lib/oxidized/web/views/versions.haml
+++ b/lib/oxidized/web/views/versions.haml
@@ -4,13 +4,13 @@
       %a{href: url_for('/nodes')} nodes
       \/ Versions for Node 
       %span.node_title #{@node}
-  
+
 .row
   .refresh-div
     %form
       %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
-        %span.glyphicon.glyphicon-repeat
-        Refresh
+        %span.glyphicon.glyphicon-repeat Refresh
+
   %table.table.table-responsive.tablesorter#versionsTable
     %thead
       %tr
@@ -21,25 +21,23 @@
         %th Actions
 
     %tbody
-      -trclass = %w(even odd)
       - nb = @data.count + 1
       - @data.each do |x|
         %tr
+          %td #{nb -= 1}
+          %td #{time_from_now x[:date]}
+          %td #{x[:author][:name]}
+          %td #{x[:message]}
           %td
-            #{nb -= 1}
-          %td
-            #{time_from_now x[:date]}
-          %td
-            #{x[:author][:name]}
-          %td
-            #{x[:message]}
-          %td
-            - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}&date=#{x[:date]}&num=#{nb}"
-            %a{title: 'configuration', href: url_for("/node/version/view?#{params}")}
+            - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}"
+            - params = "#{params}&date=#{x[:date]}&num=#{nb}"
+            %a{title: 'configuration',
+               href: url_for("/node/version/view?#{params}")}
               %span.glyphicon.glyphicon-cloud-download
             &nbsp;&nbsp;
-            %a{title: 'diff', href: url_for("/node/version/diffs?#{params}") }
+            %a{title: 'diff', href: url_for("/node/version/diffs?#{params}")}
               %img{src: url_for('/images/diff_15x17.png')}
+
 :javascript
   $(function() {
     $('#versionsTable').dataTable({


### PR DESCRIPTION
Closes #47.

Depends on #54.

Adds several new stats, adds highlighting (> 50% failures is warning, >75% failures is critical), changes refresh button to standard Bootstrap styling, displays stats for all nodes (previously only displayed data on hosts that had a failure in last 24 hours).  Removed JavaScript that didn't work to begin with.  Screenshot below.

![more-stats](https://cloud.githubusercontent.com/assets/4076147/12030379/ae57464e-adb2-11e5-92a9-0a2419d6c4a7.PNG)
