### PR TITLE
55 feat/bootstrapify

### DIFF
--- a/lib/oxidized/web/views/conf_search.haml
+++ b/lib/oxidized/web/views/conf_search.haml
@@ -10,20 +10,21 @@
     %form
       %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
         %span.glyphicon.glyphicon-repeat Refresh
-  %table.table.table-responsive.tablesorter#versionsTable
-    %thead
-      %tr
-        %th Name
-        %th Configuration
-
-    %tbody
-      - @nodes_match.each do |x|
+  .table-responsive
+    %table.table.table-condensed.table-striped.table-hover#versionsTable
+      %thead
         %tr
-          %td #{x[:node]}
-          %td
-            %a{title: 'configuration',
-               href: url_for("/node/fetch/#{x[:full_name]}")}
-              %span.glyphicon.glyphicon-cloud-download
+          %th Name
+          %th Configuration
+
+      %tbody
+        - @nodes_match.each do |x|
+          %tr
+            %td #{x[:node]}
+            %td
+              %a{title: 'configuration',
+                 href: url_for("/node/fetch/#{x[:full_name]}")}
+                %span.glyphicon.glyphicon-cloud-download
 
 :javascript
   $(function() {

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -79,3 +79,6 @@
           - line.slice! "empty_line"
           .diff-empty> #{line}
 
+        - else
+          %div> #{line}
+

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -46,16 +46,16 @@
 
 .row
   .col-sm-12
-    .diffs_old#Test
+    .diffs_old
       - @diff[:old_diff].each do |line|
         - if /^\+.*/.match(line)
-          .added#Test> #{line}
+          .added> #{line}
 
         - elsif /^\-.*/.match(line)
           .deleted> #{line}
 
         - elsif /^@@\s.*@@.*$/.match(line)
-          .diff-index#Test> #{line}
+          .diff-index> #{line}
 
         - elsif /^empty_line&nbsp;/.match(line)
           - line.slice! "empty_line"

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -1,73 +1,81 @@
-%h4
-  - if @info[:group] != ''
-    - node_full = "#{@info[:group]}/#{@info[:node]}"
-  - else
-    - node_full = "#{@info[:node]}"
-  %a{href: url_for("/node/version?node_full=#{node_full}")} versions
-  \/ Diff version #{@info[:num]} - #{@info[:num2]} for Node 
-  %span.node_title #{@info[:node]}
-- date_version = Time.parse @info[:date]
-Date of version:
-%span.time #{date_version.strftime("%d-%m-%y at %r")}
-%br
-Number of lines changed: 
-%span.added added #{@stat[0]} 
-%span.deleted removed #{@stat[1]}
-%br
-%br
-- params = "node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}"
-- params = "#{params}&date=#{@info[:date]}&num=#{@info[:num]}"
-%form{action: "/node/version/diffs?#{params}", method: 'post'}
-  %select#oid2{name: 'oid2'}
-    - diff2 = {}
-    - num = @oids_dates.count + 1
-    - next_id = false
-    - @oids_dates.each do |x|
-      %option{value: x[:oid]} Version #{num -= 1} (#{time_from_now x[:date]})
-      - if (x[:oid].to_s == @info[:oid2]) || (next_id)
-        - diff2 = {num: num, date: x[:date]}
-        - next_id = false
-      - elsif (x[:oid].to_s == @info[:oid]) && !(@info[:oid2])
-        - next_id = true
+.row
+  .col-sm-12
+    %h4
+      - if @info[:group] != ''
+        - node_full = "#{@info[:group]}/#{@info[:node]}"
+      - else
+        - node_full = "#{@info[:node]}"
+      %a{href: url_for("/node/version?node_full=#{node_full}")} versions
+      \/ Diff version #{@info[:num]} - #{@info[:num2]} for Node
+      %span.node_title #{@info[:node]}
+.row
+  .col-sm-12
+    - date_version = Time.parse @info[:date]
+    Date of version:
+    %span.time #{date_version.strftime("%d-%m-%y at %r")}
+.row
+  .col-sm-12
+    Number of lines changed:
+    %span.added added #{@stat[0]}
+    %span.deleted removed #{@stat[1]}
 
-  %input{type: 'submit', value: 'Get diffs!'}
-%br
-.old_version_title Version #{diff2[:num]} (#{time_from_now diff2[:date]})
-.new_version_title Version #{@info[:num]} (#{time_from_now @info[:date]})
-%br
-.diffs_old#Test
-  - @diff[:old_diff].each do |line|
-    - if /^\+.*/.match(line)
-      .added#Test> #{line}
-      
-    - elsif /^\-.*/.match(line)
-      .deleted> #{line}
-      
-    - elsif /^@@\s.*@@.*$/.match(line)
-      .diff-index#Test> #{line}
+.row
+  .col-sm-6
+    - params = "node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}"
+    - params = "#{params}&date=#{@info[:date]}&num=#{@info[:num]}"
+    %form{action: "/node/version/diffs?#{params}", method: 'post', role: 'form'}
+      .form-group
+        %select.form-control#oid2{name: 'oid2'}
+          - diff2 = {}
+          - num = @oids_dates.count + 1
+          - next_id = false
+          - @oids_dates.each do |x|
+            %option{value: x[:oid]} Version #{num -= 1} (#{time_from_now x[:date]})
+            - if (x[:oid].to_s == @info[:oid2]) || (next_id)
+              - diff2 = {num: num, date: x[:date]}
+              - next_id = false
+            - elsif (x[:oid].to_s == @info[:oid]) && !(@info[:oid2])
+              - next_id = true
 
-    - elsif /^empty_line&nbsp;/.match(line)
-      - line.slice! "empty_line"
-      .diff-empty> #{line}
+      %button.btn.btn-default{type: 'submit'} Get Diffs!
 
-    - else
-      %div> #{line}
+.row
+  .col-sm-12
+    .old_version_title Version #{diff2[:num]} (#{time_from_now diff2[:date]})
+    .new_version_title Version #{@info[:num]} (#{time_from_now @info[:date]})
 
-.diffs_new
-  - @diff[:new_diff].each do |line|
-    - if /^\+.*/.match(line)
-      .added> #{line}
-    
-    - elsif /^\-.*/.match(line)
-      .deleted> #{line}
-    
-    - elsif /^@@\s.*@@.*$/.match(line)
-      .diff-index> #{line}
+.row
+  .col-sm-12
+    .diffs_old#Test
+      - @diff[:old_diff].each do |line|
+        - if /^\+.*/.match(line)
+          .added#Test> #{line}
 
-    - elsif /^empty_line&nbsp;/.match(line)
-      - line.slice! "empty_line"
-      .diff-empty> #{line}
+        - elsif /^\-.*/.match(line)
+          .deleted> #{line}
 
-    - else
-      %div> #{line}
+        - elsif /^@@\s.*@@.*$/.match(line)
+          .diff-index#Test> #{line}
+
+        - elsif /^empty_line&nbsp;/.match(line)
+          - line.slice! "empty_line"
+          .diff-empty> #{line}
+
+        - else
+          %div> #{line}
+
+    .diffs_new
+      - @diff[:new_diff].each do |line|
+        - if /^\+.*/.match(line)
+          .added> #{line}
+
+        - elsif /^\-.*/.match(line)
+          .deleted> #{line}
+
+        - elsif /^@@\s.*@@.*$/.match(line)
+          .diff-index> #{line}
+
+        - elsif /^empty_line&nbsp;/.match(line)
+          - line.slice! "empty_line"
+          .diff-empty> #{line}
 

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -21,7 +21,7 @@
             %li{class: request.path_info == '/nodes/stats' ? 'active' : ''}
               %a.navbar-link{href: url_for('/nodes/stats')} Stats
 
-            %li
+            %li{class: request.path_info == '/migration' ? 'active' : ''}
               %a.navbar-link{href: url_for('/migration')} Migration
 
           %form.navbar-form.navbar-right{role: 'search',

--- a/lib/oxidized/web/views/node.haml
+++ b/lib/oxidized/web/views/node.haml
@@ -1,17 +1,18 @@
-!=haml :head
-%body
-  %h4
-    %a{href: url_for('/nodes')} nodes
-    %span /
-    =@data[:name]
-    &nbsp;
-    %a{title: 'configuration', href: url_for("/node/fetch/#{@data[:full_name]}")}
-      %span.glyphicon.glyphicon-cloud-download{style: 'color: #000; font-size: 14px;'}
-    %a{title: 'versions',
-       href: url_for("/node/version?node_full=#{@data[:full_name]}")}
-      %img{src: url_for('/images/versioning_18px.png')}
-    %a{title: 'update', href: url_for("/node/next/#{@data[:full_name]}")}
-      %span.glyphicon.glyphicon-repeat{style: 'color: #000; font-size: 14px;'}
-  -out='';PP.pp(@data,out)
-  %pre
-    = preserve "#{out}"
+.row
+  .col-sm-12
+    %h4
+      %a{href: url_for('/nodes')} nodes
+      %span /
+      =@data[:name]
+      &nbsp;
+      %a{title: 'configuration', href: url_for("/node/fetch/#{@data[:full_name]}")}
+        %span.glyphicon.glyphicon-cloud-download{style: 'color: #000; font-size: 14px;'}
+      %a{title: 'versions',
+         href: url_for("/node/version?node_full=#{@data[:full_name]}")}
+        %img{src: url_for('/images/versioning_18px.png')}
+      %a{title: 'update', href: url_for("/node/next/#{@data[:full_name]}")}
+        %span.glyphicon.glyphicon-repeat{style: 'color: #000; font-size: 14px;'}
+    - out = '';PP.pp(@data,out)
+    %pre
+      = preserve "#{out}"
+

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -9,7 +9,7 @@
         %span.glyphicon.glyphicon-repeat Refresh
 
   .table-responsive
-    %table.table.table-striped.table-hover.table-condensed.tablesorter#nodesTable
+    %table.table.table-striped.table-hover.table-condensed#nodesTable
       %thead
         %tr
           %th Name

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -9,76 +9,77 @@
     %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
       %span.glyphicon.glyphicon-repeat Refresh
 
-  %table.table.table-responsive.table-condensed.table-striped.table-hover.tablesorter#statsTable
-    %caption
-      %span Node Statistics
+  .table-responsive
+    %table.table.table-condensed.table-striped.table-hover#statsTable
+      %caption
+        %span Node Statistics
 
-    %thead
-      %tr
-        %th Name
-        %th Total Runs
-        %th Total Failures
-        %th Failure Rate
-        %th Average Run Time
-        %th Last Status
-        %th Last Update
-        %th Last Failure
+      %thead
+        %tr
+          %th Name
+          %th Total Runs
+          %th Total Failures
+          %th Failure Rate
+          %th Average Run Time
+          %th Last Status
+          %th Last Update
+          %th Last Failure
 
-    %tbody
-      - @data.map do |node, stats|
-        - status = 'no_connection'
-        - successes = 0
-        - failures = 0
-        - avg_success_time = 0
-        - avg_failure_time = 0
-        - avg_time = 0
-        - row_class = ''
+      %tbody
+        - @data.map do |node, stats|
+          - status = 'no_connection'
+          - successes = 0
+          - failures = 0
+          - avg_success_time = 0
+          - avg_failure_time = 0
+          - avg_time = 0
+          - row_class = ''
 
-        - if stats[:success]
-          - last_success = stats[:success].last[:end]
-          - successes = stats[:success].length
-          - avg_success_time = stats[:success].collect {|x| x[:time]}
-          - avg_success_time = avg_success_time.inject {|sum, x| sum + x}
-          - avg_success_time /= successes
+          - if stats[:success]
+            - last_success = stats[:success].last[:end]
+            - successes = stats[:success].length
+            - avg_success_time = stats[:success].collect {|x| x[:time]}
+            - avg_success_time = avg_success_time.inject {|sum, x| sum + x}
+            - avg_success_time /= successes
 
-        - if stats[:no_connection]
-          - last_failure = stats[:no_connection].last[:end]
-          - failures = stats[:no_connection].length
-          - avg_failure_time = stats[:no_connection].collect {|x| x[:time]}
-          - avg_failure_time = avg_failure_time.inject {|sum, x| sum + x}
-          - avg_failure_time /= failures
+          - if stats[:no_connection]
+            - last_failure = stats[:no_connection].last[:end]
+            - failures = stats[:no_connection].length
+            - avg_failure_time = stats[:no_connection].collect {|x| x[:time]}
+            - avg_failure_time = avg_failure_time.inject {|sum, x| sum + x}
+            - avg_failure_time /= failures
 
-        - if avg_success_time > 0 && avg_failure_time > 0
-          - avg_time = (avg_success_time + avg_failure_time) / 2
-        - elsif avg_success_time > 0
-          - avg_time = avg_success_time
-        - elsif avg_failure_time > 0
-          - avg_time = avg_failure_time
-        - avg_time = "#{'%.2f' % avg_time}" unless avg_time == 'Unknown'
+          - if avg_success_time > 0 && avg_failure_time > 0
+            - avg_time = (avg_success_time + avg_failure_time) / 2
+          - elsif avg_success_time > 0
+            - avg_time = avg_success_time
+          - elsif avg_failure_time > 0
+            - avg_time = avg_failure_time
+          - avg_time = "#{'%.2f' % avg_time}" unless avg_time == 'Unknown'
 
-        - if last_success && last_failure
-          - status = last_success > last_failure ? 'success' : 'no_connection'
-        - elsif last_success
-          - status = 'success'
-          - last_failure = 'Never'
-        - else
-          - last_success = 'Never'
+          - if last_success && last_failure
+            - status = last_success > last_failure ? 'success' : 'no_connection'
+          - elsif last_success
+            - status = 'success'
+            - last_failure = 'Never'
+          - else
+            - last_success = 'Never'
 
-        - total_runs = successes + failures
-        - failure_rate = (failures / total_runs.to_f) * 100
-        - row_class = 'warning' if failure_rate >= 50
-        - row_class = 'danger' if failure_rate >= 75
+          - total_runs = successes + failures
+          - failure_rate = (failures / total_runs.to_f) * 100
+          - row_class = 'warning' if failure_rate >= 50
+          - row_class = 'danger' if failure_rate >= 75
 
-        %tr{class: row_class}
-          %td= node
-          %td= total_runs
-          %td= failures
-          %td #{'%.2f' % failure_rate}%
-          %td #{'%.2f' % avg_time}s
-          %td
-            %div{title: status, class: status}
-          %td.time= last_success
-          %td.time= last_failure
+          %tr{class: row_class}
+            %td= node
+            %td= total_runs
+            %td= failures
+            %td #{'%.2f' % failure_rate}%
+            %td #{'%.2f' % avg_time}s
+            %td
+              %div{title: status, class: status}
+            %td.time= last_success
+            %td.time= last_failure
 
 :javascript
   $(function() {

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -1,17 +1,22 @@
-%h4
-  - if @info[:group] != ''
-    - params = "node_full=#{@info[:group] + '/' + @info[:node]}"
-  - else
-    - params = "node_full=#{@info[:node]}"
-  %a{href: url_for("/node/version?#{params}")} versions
-  \/ version #{@info[:num]} for Node
-  %span.node_title #{@info[:node]}
+.row
+  .col-sm-12
+    %h4
+      - if @info[:group] != ''
+        - params = "node_full=#{@info[:group] + '/' + @info[:node]}"
+      - else
+        - params = "node_full=#{@info[:node]}"
+      %a{href: url_for("/node/version?#{params}")} versions
+      \/ version #{@info[:num]} for Node
+      %span.node_title #{@info[:node]}
+.row
+  .col-sm-12
+    - date_version = Time.parse @info[:date]
+    Date of version:
+    %span.time #{date_version.strftime('%Y-%m-%d %H:%M:%S %Z')}
 
-- date_version = Time.parse @info[:date]
-Date of version: 
-%span.time #{date_version.strftime('%Y-%m-%d %H:%M:%S %Z')}
-%br
-%br
-.diffs
-  - @data.each_line do |line|
-    %div> #{line}
+.row
+  .col-sm-12
+    .diffs
+      - @data.each_line do |line|
+        %div> #{line}
+

--- a/lib/oxidized/web/views/versions.haml
+++ b/lib/oxidized/web/views/versions.haml
@@ -10,33 +10,33 @@
     %form
       %button.ColVis_Button{type: 'button', onclick: 'history.go();'}
         %span.glyphicon.glyphicon-repeat Refresh
-
-  %table.table.table-responsive.tablesorter#versionsTable
-    %thead
-      %tr
-        %th Version
-        %th Dates
-        %th Author
-        %th Message
-        %th Actions
-
-    %tbody
-      - nb = @data.count + 1
-      - @data.each do |x|
+  .table-responsive
+    %table.table.table-condensed.table-striped.table-hover#versionsTable
+      %thead
         %tr
-          %td #{nb -= 1}
-          %td #{time_from_now x[:date]}
-          %td #{x[:author][:name]}
-          %td #{x[:message]}
-          %td
-            - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}"
-            - params = "#{params}&date=#{x[:date]}&num=#{nb}"
-            %a{title: 'configuration',
-               href: url_for("/node/version/view?#{params}")}
-              %span.glyphicon.glyphicon-cloud-download
-            &nbsp;&nbsp;
-            %a{title: 'diff', href: url_for("/node/version/diffs?#{params}")}
-              %img{src: url_for('/images/diff_15x17.png')}
+          %th Version
+          %th Dates
+          %th Author
+          %th Message
+          %th Actions
+
+      %tbody
+        - nb = @data.count + 1
+        - @data.each do |x|
+          %tr
+            %td #{nb -= 1}
+            %td #{time_from_now x[:date]}
+            %td #{x[:author][:name]}
+            %td #{x[:message]}
+            %td
+              - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}"
+              - params = "#{params}&date=#{x[:date]}&num=#{nb}"
+              %a{title: 'configuration',
+                 href: url_for("/node/version/view?#{params}")}
+                %span.glyphicon.glyphicon-cloud-download
+              &nbsp;&nbsp;
+              %a{title: 'diff', href: url_for("/node/version/diffs?#{params}")}
+                %img{src: url_for('/images/diff_15x17.png')}
 
 :javascript
   $(function() {


### PR DESCRIPTION
Closes #55.

Updates all tables to have same responsive, condensed, striped, and hover-enabled styling.
Removes extraneous `body` and `include head`.
Removes unused `#Test` id.
Neatens up code to be placed in row and col divs.
