### PR TITLE
Misc Code Climate Changes

### DIFF
--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -6,15 +6,15 @@ module Oxidized
       require 'rack/handler'
       attr_reader :thread
       Rack::Handler::WEBrick = Rack::Handler.get(:puma)
-      def initialize nodes, listen
+      def initialize(nodes, listen)
         require 'oxidized/web/webapp'
         listen, uri = listen.split '/'
         addr, port = listen.split ':'
-        port, addr = addr, nil if not port
-        uri = '/' + uri.to_s
+        port, addr = addr, nil unless port
+        uri = "/#{uri}"
         @opts = {
           Host: addr,
-          Port: port,
+          Port: port
         }
         WebApp.set :nodes, nodes
         @app = Rack::Builder.new do

--- a/lib/oxidized/web/mig.rb
+++ b/lib/oxidized/web/mig.rb
@@ -28,7 +28,7 @@ module Oxidized
                 if line.length > i + 2
                   h = hash[line[i + 1]]
                   h[:password] = line[i + 2]
-                  h[:enable] = line[i + 3] if line[i + 3].match(/\s*/)
+                  h[:enable] = line[i + 3] if /\s*/.match(line[i + 3])
                   hash[line[i + 1]] = h
                 elsif line.length = i + 2
                   h = hash[line[i + 1]]

--- a/lib/oxidized/web/mig.rb
+++ b/lib/oxidized/web/mig.rb
@@ -28,7 +28,7 @@ module Oxidized
                 if line.length > i + 2
                   h = hash[line[i + 1]]
                   h[:password] = line[i + 2]
-                  h[:enable] = line[i + 3] if line[i + 3].match /\s*/
+                  h[:enable] = line[i + 3] if line[i + 3].match(/\s*/)
                   hash[line[i + 1]] = h
                 elsif line.length = i + 2
                   h = hash[line[i + 1]]

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -209,7 +209,7 @@ module Oxidized
           @data = nodes.get_diff node, @info[:group], @info[:oid], nil
         end
         @stat = %w(null null)
-        unless @data == 'no diffs' && @data.nil?
+        if @data != 'no diffs' && !@data.nil?
           @stat = @data[:stat]
           @data = @data[:patch]
         else
@@ -226,7 +226,7 @@ module Oxidized
 
       private
 
-      def out(template=:default)
+      def out(template = :default)
         if @json || params[:format] == 'json'
           if @data.is_a?(String)
             json @data.lines


### PR DESCRIPTION
Related to #68.

Parens around method arguments
More spacing fixes
Use modifier form of `if` and `unless` where appropriate
Refuse useless commas
More quotation fixes
Remove redundant hash symbol in method calls
Split some hashes onto multiple lines
Use `+=` operator
Use `%w()` for creating arrays of strings
Use `||` instead of `or`.