### PR TITLE
Change symbol declaration with hyphens.

### DIFF
--- a/lib/oxidized/web/views/head.haml
+++ b/lib/oxidized/web/views/head.haml
@@ -1,6 +1,6 @@
 %head
   %meta{charset: 'utf-8'}
-  %meta{'meta-equiv': 'X-UA-Compatible', content: 'IE=edge'}
+  %meta{:'meta-equiv' => 'X-UA-Compatible', content: 'IE=edge'}
   %meta{name: 'viewport', content: 'width=device-width, initial-scale=1'}
   %title oxidized
   %link{rel: 'stylesheet', href: url_for('/css/bootstrap.min.css')}

--- a/lib/oxidized/web/views/layout.haml
+++ b/lib/oxidized/web/views/layout.haml
@@ -6,9 +6,9 @@
       .container-fluid
         .navbar-header
           %button.navbar-toggle.collapsed{type: 'button',
-                                          'data-toggle': 'collapse',
-                                          'data-target': '#ox-nav',
-                                          'aria-expanded': 'false'}
+                                          :'data-toggle' => 'collapse',
+                                          :'data-target' => '#ox-nav',
+                                          :'aria-expanded' => 'false'}
             %span.sr-only Toggle Navigation
             %span.icon-bar
             %span.icon-bar


### PR DESCRIPTION
Resolves an issue for Ruby versions prior to 2.2 that causes symbol keys
with hyphens in them using the new (1.9) hash syntax to generate an
error.

This is done by reverting those symbols to pre-1.9 syntax, as in:

`:'example-key' => 'value'`

See ytti/oxidized-web#84