### PR TITLE
Change default output to text.

### DIFF
--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -221,7 +221,7 @@ module Oxidized
 
       private
 
-      def out template = :default
+      def out template = :text
         if @json or params[:format] == 'json'
           if @data.is_a?(String)
             json @data.lines


### PR DESCRIPTION
default.haml was removed in 391481a, breaking a few routes.
Change the default template to `:text`, which has similar functionality
to the old default.haml.

See ytti/oxidized-web#88