### PR TITLE
Fix Paginated Timestamp Display

### DIFF
--- a/lib/oxidized/web/public/scripts/oxidized.js
+++ b/lib/oxidized/web/public/scripts/oxidized.js
@@ -91,6 +91,10 @@ $(function() {
       .always(function() {
         $('#flashMessage').removeClass('hidden');
       });
+
+  // Update timestamp on next button click for DataTables
+  $('.paginate_button').on('click', function() {    
+    convertTime();
   });
 });
 


### PR DESCRIPTION
Use jQuery's `click` function to update the display of timestamps when a pagination button is clicked.

Closes #91.