### PR TITLE
Filter by model or group

### DIFF
--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -32,8 +32,10 @@
             %td
               %a{href: url_for("/node/show/#{node[:name]}")} #{node[:name]}
             %td= node[:ip]
-            %td= node[:model]
-            %td= node[:group]
+            %td
+              %a{href: url_for("/nodes/model/#{node[:model]}")} #{node[:model]}
+            %td
+              %a{href: url_for("/nodes/group/#{node[:group]}")} #{node[:group]}
             %td
               %div{title: node[:status], class: node[:status]}
                 %span{style: 'visibility: hidden'}#{node[:status]}


### PR DESCRIPTION
Makes each model and group into a link on the nodes page to allow for quick filtering of model or group.