### PR TITLE
Add necessary stuff before oxidized base patch to hide enable password from REST API

### DIFF
--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -6,7 +6,9 @@ module Oxidized
       require 'rack/handler'
       attr_reader :thread
       Rack::Handler::WEBrick = Rack::Handler.get(:puma)
-      def initialize nodes, listen
+      # in order to don't crash existing setup,
+      # we set hide_enable at false by default
+      def initialize nodes, listen, hide_enable=false
         require 'oxidized/web/webapp'
         listen, uri = listen.split '/'
         addr, port = listen.split ':'
@@ -17,6 +19,7 @@ module Oxidized
           Port: port,
         }
         WebApp.set :nodes, nodes
+        WebApp.set :hide_enable, hide_enable
         @app = Rack::Builder.new do
           map uri do
             run WebApp

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -26,7 +26,6 @@ module Oxidized
               node[:time]   = node[:last][:end]
             end
             hide_enable? node
-            node
           end
         end
         out :nodes
@@ -42,7 +41,6 @@ module Oxidized
             node[:time]   = node[:last][:end]
           end
           hide_enable? node
-          node
         end
         out :nodes
       end
@@ -114,8 +112,7 @@ module Oxidized
 
       get '/node/show/:node' do
         node, @json = route_parse :node
-        @data = nodes.show node
-        hide_enable? @data
+        @data = hide_enable?(nodes.show(node))
         out :node
       end
 
@@ -226,10 +223,21 @@ module Oxidized
 
       def hide_enable? node
         if settings.hide_enable
+          # We need to dup/clone twice not to break in memory node.
           if (node.has_key? :vars) and (node[:vars].has_key? :enable)
-            node[:vars][:enable] = 'HIDDEN'
+            n = node.clone
+            node.each_key do |k|
+              if node[k].is_a?(Symbol)
+                n[k] = node[k]
+              else
+                n[k] = node[k].dup unless node[k].nil?
+              end
+            end
+            n[:vars][:enable] = 'HIDDEN'
+            return n
           end
         end
+        return node
       end
 
       def out template = :text

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -25,6 +25,7 @@ module Oxidized
               node[:status] = node[:last][:status]
               node[:time]   = node[:last][:end]
             end
+            hide_enable? node
             node
           end
         end
@@ -40,6 +41,7 @@ module Oxidized
             node[:status] = node[:last][:status]
             node[:time]   = node[:last][:end]
           end
+          hide_enable? node
           node
         end
         out :nodes
@@ -113,6 +115,7 @@ module Oxidized
       get '/node/show/:node' do
         node, @json = route_parse :node
         @data = nodes.show node
+        hide_enable? @data
         out :node
       end
 
@@ -220,6 +223,14 @@ module Oxidized
       end
 
       private
+
+      def hide_enable? node
+        if settings.hide_enable
+          if (node.has_key? :vars) and (node[:vars].has_key? :enable)
+            node[:vars][:enable] = 'HIDDEN'
+          end
+        end
+      end
 
       def out template = :text
         if @json or params[:format] == 'json'


### PR DESCRIPTION
I would like to have the ability to hide enable password from oxidized's REST API like:

{
        "full_name": "a-device", 
        "group": "default", 
        "ip": "10.10.10.10", 
        "last": {
            "end": "2016-04-12 12:21:51 UTC", 
            "start": "2016-04-12 12:21:25 UTC", 
            "status": "success", 
            "time": 26.277578618
        }, 
        "model": "a-model", 
        "name": "a-device", 
        "status": "success", 
        "time": "2016-04-12 12:21:51 UTC", 
        "vars": {
            "enable": "HIDDEN"
        }

This patch doesn't break actual setup for users using clear password.

Patch for oxidized base project is coming (TM).

Tib
