### PR TITLE
Fix timezone conversion on page load

### DIFF
--- a/lib/oxidized/web/public/scripts/oxidized.js
+++ b/lib/oxidized/web/public/scripts/oxidized.js
@@ -44,7 +44,7 @@ var convertTime = function() {
   */
   $('.time').each(function() {
     var content = $(this).text();
-    if(content === 'never') { return; }
+    if(content === 'never' || content === '') { return; }
     var utcTime = content.split(' ');
     var date = new Date(utcTime[0] + 'T' + utcTime[1] + 'Z');
     var year = date.getFullYear();


### PR DESCRIPTION
Sometimes, the last update date is blank, which results in convertTime() failing:
Uncaught TypeError: Cannot read property '0' of null
    at HTMLTableCellElement.<anonymous> (oxidized.js:56)
    at Function.each (jquery-2.1.1.min.js:2)
    at n.fn.init.each (jquery-2.1.1.min.js:2)
    at convertTime (oxidized.js:45)
    at HTMLDocument.<anonymous> (oxidized.js:64)
    at j (jquery-2.1.1.min.js:2)
    at Object.fireWith [as resolveWith] (jquery-2.1.1.min.js:2)
    at Function.ready (jquery-2.1.1.min.js:2)
    at HTMLDocument.I (jquery-2.1.1.min.js:2)
(anonymous) @ oxidized.js:56
each @ jquery-2.1.1.min.js:2
each @ jquery-2.1.1.min.js:2
convertTime @ oxidized.js:45
(anonymous) @ oxidized.js:64
j @ jquery-2.1.1.min.js:2
fireWith @ jquery-2.1.1.min.js:2
ready @ jquery-2.1.1.min.js:2
I @ jquery-2.1.1.min.js:2

Since this seems to happen on the very first date conversion, no timezone conversion ever happened.