### PR TITLE
Disable chrome auto-translation

### DIFF
--- a/lib/oxidized/web/views/head.haml
+++ b/lib/oxidized/web/views/head.haml
@@ -2,6 +2,7 @@
   %meta{charset: 'utf-8'}
   %meta{:'meta-equiv' => 'X-UA-Compatible', content: 'IE=edge'}
   %meta{name: 'viewport', content: 'width=device-width, initial-scale=1'}
+  %meta{name: 'google', content: 'notranslate'}
   %title oxidized
   %link{rel: 'stylesheet', href: url_for('/css/bootstrap.min.css')}
   %link{rel: 'stylesheet', href: url_for('/css/oxidized.css')}


### PR DESCRIPTION
Chrome likes to incorrectly try to translate the page.  This generally doesn't actually accomplish anything, and just screws up the page contents.  Automatic translation really isn't relevant to router configs, so suggest to Chrome to not auto-translate things.