### PR TITLE
Corrected relod function to use relative uri

### DIFF
--- a/lib/oxidized/web/public/scripts/oxidized.js
+++ b/lib/oxidized/web/public/scripts/oxidized.js
@@ -71,10 +71,10 @@ $(function() {
   $('.btn-file :file').on('fileSelect', function(e, numFiles, label) {
     $(this).parents('.input-group').find(':text').val(label);
   });
-  
+
   // Reloads the nodes from a source by calling the /reload.json URI
   $('#reload').click(function() {
-    $.get('/reload.json')
+    $.get('./reload.json')
       .done(function(data) {
         $('#flashMessage')
         .removeClass('alert-danger')
@@ -94,9 +94,7 @@ $(function() {
   });
 
   // Update timestamp on next button click for DataTables
-  $('.paginate_button').on('click', function() {    
+  $('.paginate_button').on('click', function() {
     convertTime();
   });
 });
-
-


### PR DESCRIPTION
This should fix the problem with the reload button when Oxidized is deployed under example.com/path. (https://github.com/ytti/oxidized/issues/724)