### PR TITLE
Fixes in urls when deployed under non-root path

### DIFF
--- a/lib/oxidized/web/public/scripts/oxidized.js
+++ b/lib/oxidized/web/public/scripts/oxidized.js
@@ -74,7 +74,7 @@ $(function() {
 
   // Reloads the nodes from a source by calling the /reload.json URI
   $('#reload').click(function() {
-    $.get('./reload.json')
+    $.get(window.location.pathname.replace(/nodes.*/g, '')+'reload.json')
       .done(function(data) {
         $('#flashMessage')
         .removeClass('alert-danger')

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -23,7 +23,7 @@
   .col-sm-6
     - params = "node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}"
     - params = "#{params}&date=#{@info[:date]}&num=#{@info[:num]}"
-    %form{action: "/node/version/diffs?#{params}", method: 'post', role: 'form'}
+    %form{action: url_for("/node/version/diffs?#{params}"), method: 'post', role: 'form'}
       .form-group
         %select.form-control#oid2{name: 'oid2'}
           - diff2 = {}
@@ -101,4 +101,3 @@
           %div>
             :escaped
               #{line}
-


### PR DESCRIPTION
Corrected https://github.com/ytti/oxidized-web/issues/121

Also noticed that my last commit in reload button does not work in group view and the script tries to get /oxidized-root/nodes/group/reload.json instead of /oxidized-root/reload.json. This regex should fix this and hope there is no more different views using this same reload button.