### PR TITLE
fix typo in gemspec

### DIFF
--- a/oxidized-web.gemspec
+++ b/oxidized-web.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'haml',                '~> 4.0'
   s.add_runtime_dependency 'sass',                '~> 3.3'
   s.add_runtime_dependency 'emk-sinatra-url-for', '~> 0.2'
-  s.add_runtime_dependency 'htmlentitites',       '~> 4.3'
+  s.add_runtime_dependency 'htmlentities',        '~> 4.3'
 end


### PR DESCRIPTION
It is 'htmlentities' instead of 'htmlentitites'.