### PR TITLE
Diff ver spacing

### DIFF
--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -49,55 +49,55 @@
     .diffs_old
       - @diff[:old_diff].each do |line|
         - if /^\+.*/.match(line)
-          .added>
+          .added><
             :escaped
               #{line}
 
         - elsif /^\-.*/.match(line)
-          .deleted>
+          .deleted><
             :escaped
               #{line}
 
         - elsif /^@@\s.*@@.*$/.match(line)
-          .diff-index>
+          .diff-index><
             :escaped
               #{line}
 
         - elsif /^empty_line&nbsp;/.match(line)
           - line.slice! "empty_line"
-          .diff-empty>
+          .diff-empty><
             :escaped
               #{line}
 
         - else
-          %div>
+          %div><
             :escaped
               #{line}
 
     .diffs_new
       - @diff[:new_diff].each do |line|
         - if /^\+.*/.match(line)
-          .added>
+          .added><
             :escaped
               #{line}
 
         - elsif /^\-.*/.match(line)
-          .deleted>
+          .deleted><
             :escaped
               #{line}
 
         - elsif /^@@\s.*@@.*$/.match(line)
-          .diff-index>
+          .diff-index><
             :escaped
               #{line}
 
         - elsif /^empty_line&nbsp;/.match(line)
           - line.slice! "empty_line"
-          .diff-empty>
+          .diff-empty><
             :escaped
               #{line}
 
         - else
-          %div>
+          %div><
             :escaped
               #{line}

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -18,6 +18,6 @@
   .col-sm-12
     .diffs
       - @data.each_line do |line|
-        %div>
+        %div><
           :escaped
             #{line}


### PR DESCRIPTION
Fixes the _leading & trailing_ whitespace between a the `<div>` tag and the actual backed-up configuration.
This seems like it was introduced in #116 & is present in 'oxidized-web-0.9.1'
Fixes issue #132 

My instance looks like the demo running at http://oxidized.arahant.net/ now in term of spacing on diffs and version