### PR TITLE
bugfix: oxidized cannot exit via ctrl-c

### DIFF
--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -25,7 +25,10 @@ module Oxidized
       end
 
       def run
-        @thread = Thread.new { Rack::Handler::Puma.run @app, @opts }
+        @thread = Thread.new do
+          Rack::Handler::Puma.run @app, @opts
+          exit!
+        end
       end
     end
   end


### PR DESCRIPTION
**Purpose**
if oxidized is run with web interface oxidized cannot be closed by ctrl-c
![image](https://user-images.githubusercontent.com/2146069/39049343-cad6e230-44a9-11e8-8353-f2fc390e967f.png)
this PR fixes this problem