### PR TITLE
Feature lockout support

### DIFF
--- a/lib/oxidized/web/views/sass/oxidized.sass
+++ b/lib/oxidized/web/views/sass/oxidized.sass
@@ -84,6 +84,9 @@ tr.ox-status-no_connection
 .never
     @extend .status
     background-color: #58ACFA
+.locked
+    @extend .status
+    background-color: #FFA833
 
 a:hover
     text-decoration: none

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -42,6 +42,13 @@
             - avg_success_time = avg_success_time.inject {|sum, x| sum + x}
             - avg_success_time /= successes
 
+          - if stats[:locked]
+            - last_locked = stats[:locked].last[:end]
+            - successes = stats[:locked].length
+            - avg_success_time = stats[:locked].collect {|x| x[:time]}
+            - avg_success_time = avg_success_time.inject {|sum, x| sum + x}
+            - avg_success_time /= successes
+
           - if stats[:no_connection]
             - last_failure = stats[:no_connection].last[:end]
             - failures = stats[:no_connection].length
@@ -59,6 +66,8 @@
 
           - if last_success && last_failure
             - status = last_success > last_failure ? 'success' : 'no_connection'
+          - elsif last_locked
+            - status = 'locked'
           - elsif last_success
             - status = 'success'
             - last_failure = 'never'


### PR DESCRIPTION
Bring in basic support for a locked node status - as proposed by oxidized PR https://github.com/ytti/oxidized/pull/1329

This will color the last node status as an orange-ish color. 

