### PR TITLE
pessimistic puma lock on 3.11 as 3.12 requires ruby 2.2+

### DIFF
--- a/oxidized-web.gemspec
+++ b/oxidized-web.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'haml',                '~> 5.0'
   s.add_runtime_dependency 'htmlentities',        '~> 4.3'
   s.add_runtime_dependency 'oxidized',            '~> 0.22'
-  s.add_runtime_dependency 'puma',                '~> 3'
+  s.add_runtime_dependency 'puma',                '~> 3.11.4'
   s.add_runtime_dependency 'sass',                '~> 3.3'
   s.add_runtime_dependency 'sinatra',             '~> 1.4', '>= 1.4.6'
   s.add_runtime_dependency 'sinatra-contrib',     '~> 1.4', '>= 1.4.6'


### PR DESCRIPTION
Per Puma's [History](https://github.com/puma/puma/blob/master/History.md), Puma 3.12 has been restricted to Ruby 2.2+. As Oxidized currently targets Ruby 2.0+, lock Puma to the more recent suitable version.

Closes ytti/oxidized#1457