### PR TITLE
escape user input to fix XSS "vulnerability"

### DIFF
--- a/lib/oxidized/web/views/conf_search.haml
+++ b/lib/oxidized/web/views/conf_search.haml
@@ -3,7 +3,8 @@
     %h4
       %a{href: url_for('/nodes')} nodes
       \/ Nodes that contain 
-      %span "#{@to_research}"
+      %span
+        &= "#{@to_research}"
   
 .row
   .pull-right


### PR DESCRIPTION
XSS vulnerability reported as part of a pentest, this escapes the user input when printing back to the title of the page.

I've had a brief look around and can't find any other user input that's rendered back in to a page.