### PR TITLE
Allow node to be optionally provided to /reload endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
 
+Metrics/ClassLength:
+  Max: 300
+
 StringLiterals:
   Enabled: false
 

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -71,8 +71,9 @@ module Oxidized
       end
 
       get '/reload.?:format?' do
-        nodes.load
-        @data = 'reloaded list of nodes'
+        node = params[:node]
+        node ? (nodes.load node) : nodes.load
+        @data = node ? "reloaded #{node}" : 'reloaded list of nodes'
         out
       end
 


### PR DESCRIPTION
This PR changes the `/reload` endpoint to allow a `node`'s name to be passed in and have only that single node reloaded, instead of all nodes.

This supersedes PR https://github.com/ytti/oxidized-web/pull/189, which will be closed in due course