### PR TITLE
Fix a bug where uri contained only the first sub-uri given by the user

### DIFF
--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -8,7 +8,7 @@ module Oxidized
       Rack::Handler::WEBrick = Rack::Handler.get(:puma)
       def initialize nodes, listen
         require 'oxidized/web/webapp'
-        listen, uri = listen.split '/'
+        listen, uri = listen.split('/')[0], listen.split('/')[1..listen.length].join('/')
         addr, _, port = listen.rpartition ':'
         port, addr = addr, nil if not port
         uri = '/' + uri.to_s


### PR DESCRIPTION
This commit fix a bug where the given rest uri in oxidized config was not taken entirely if there was multiple '/'.

- Example of what worked :

   `rest: 127.0.0.1:8888/oxidized`

- Example of what was broken : 

   `rest: 127.0.0.1:8888/network/backups`
   In this case, the base uri will be _/network_ instead of _/network/backups_, this commit fix this.

Thank you for the oxidized web interface !
Please let me know if something's not ok with this MR

Regards,
David Loup