### PR TITLE
display timezone as offset

### DIFF
--- a/lib/oxidized/web/public/scripts/oxidized.js
+++ b/lib/oxidized/web/public/scripts/oxidized.js
@@ -53,7 +53,7 @@ var convertTime = function() {
     var hour = ("0" + date.getHours()).slice(-2);
     var minute = ("0" + date.getMinutes()).slice(-2);
     var second = ("0" + date.getSeconds()).slice(-2);
-    var timeZone = date.toString().match(/\(.*\)/)[0].match(/[A-Z]/g).join('');
+    var timeZone = date.toString().match(/[A-Z]{3,4}[+-][0-9]{4}/)[0];
     $(this).text(year + '-' + month + '-' + day + ' ' + hour + ':' + minute + ':' + second + ' ' + timeZone);
   });
 };


### PR DESCRIPTION
The previous regexp relied on extracting Latin alphabet capital letters and using them as a timezone name and broke on browsers with non-English locales, such as in #194, #186. Extract timezone offset instead. 