### PR TITLE
adding basic auth

### DIFF
--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -13,6 +13,12 @@ module Oxidized
       helpers Sinatra::UrlForHelper
       set :public_folder, Proc.new { File.join(root, 'public') }
 
+      if ENV["BASIC_AUTH_USERNAME"] && ENV["BASIC_AUTH_PASSWORD"]
+        use Rack::Auth::Basic, "Restricted Area" do |username, password|
+          username == ENV["BASIC_AUTH_USERNAME"] and password == ENV["BASIC_AUTH_PASSWORD"]
+        end
+      end
+
       get '/' do
         redirect url_for('/nodes')
       end


### PR DESCRIPTION
This is an extremely basic way to add basic authentication for oxidizied-web. User can set environment variables BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD, after which all the requests to the oxidized will need to provide basic authentication. LibreNMS integration remains functional, as one can provide UN/PW in the URL.

I am aware that one can easily add reverse proxy to achieve the same functionality, but I feel that having ability to do it quickly and easily via environment variables would simplify things for those who choose to run oxidized in container environments.