### PR TITLE
support puma6

### DIFF
--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -3,9 +3,8 @@ require 'json'
 module Oxidized
   module API
     class Web
-      require 'rack/handler'
+      require 'rack/handler/puma'
       attr_reader :thread
-      Rack::Handler::WEBrick = Rack::Handler.get(:puma)
       def initialize nodes, listen
         require 'oxidized/web/webapp'
         listen, uri = listen.split '/'
@@ -26,7 +25,7 @@ module Oxidized
 
       def run
         @thread = Thread.new do
-          Rack::Handler::Puma.run @app, @opts
+          Rack::Handler::Puma.run @app, **@opts
           exit!
         end
       end


### PR DESCRIPTION
oxidized-web will run happily with any version of puma up to 5.6.5. However `Rack::Handler.get(:puma)` no longer works as a construct in puma 6.x.

This can be fixed by removing references to `Rack::Handler::WEBrick`, and calling the puma handler directly.

This references the problem in #238