### PR TITLE
Fix haml issues

### DIFF
--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -3,6 +3,10 @@ require 'sinatra/json'
 require 'sinatra/url_for'
 require 'tilt/haml'
 require 'sass'
+# We need PP in node.haml, but rubocop can't see this
+# rubocop:disable Lint/RedundantRequireStatement
+require 'pp'
+# rubocop:enable Lint/RedundantRequireStatement
 require 'oxidized/web/mig'
 require 'htmlentities'
 require 'charlock_holmes'
@@ -11,6 +15,7 @@ module Oxidized
     class WebApp < Sinatra::Base
       helpers Sinatra::UrlForHelper
       set :public_folder, proc { File.join(root, 'public') }
+      set :haml, { escape_html: false }
 
       get '/' do
         redirect url_for('/nodes')

--- a/oxidized-web.gemspec
+++ b/oxidized-web.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'charlock_holmes',     '~> 0.7.5'
   s.add_runtime_dependency 'emk-sinatra-url-for', '~> 0.2'
-  s.add_runtime_dependency 'haml',                '>= 5', '< 7'
+  s.add_runtime_dependency 'haml',                '~> 6.0'
   s.add_runtime_dependency 'htmlentities',        '~> 4.3'
   s.add_runtime_dependency 'json',                '~> 2.3'
   s.add_runtime_dependency 'oxidized',            '~> 0.26'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
- since haml 6.0, escape_html: true is default, we need false (old default)
- fixing haml Release to ~> 6.0
- we explicit need PP for node.haml to work (reverting part of commit 079f06a)
