### PR TITLE
Change erroneous json key in spec/node_spec.rb

### DIFF
--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -66,9 +66,9 @@ describe Oxidized::API::WebApp do
     end
 
     # Don't know if this feature is used by anyone...
-    it 'attaches author/email/message to the commit when using put and json' do
+    it 'attaches user/email/message to the commit when using put and json' do
       data = {
-        'author' => 'me',
+        'user' => 'me',
         'email' => 'me@example.com',
         'message' => 'minitest, rack/test & mock simply rock',
         'from' => 'unused variable!'
@@ -83,7 +83,7 @@ describe Oxidized::API::WebApp do
 
     it 'attaches data to the commit when using a group and put, then redirects' do
       data = {
-        'author' => 'me',
+        'user' => 'me',
         'email' => 'me@example.com',
         'message' => 'minitest, rack/test & mock simply rock',
         'from' => 'unused variable!'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
The JSON key in the object PUT to /node/next should be "user" and not "author". See https://github.com/ytti/oxidized/blob/master/lib/oxidized/nodes.rb#L79

