### PR TITLE
Add Ruby head (3.5) to CI and deprecation warnings for frozen string literals

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4', 'ruby-head']
+    continue-on-error: ${{ matrix.ruby-version == 'ruby-head' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,7 @@ task :test do
   Rake::TestTask.new do |t|
     t.libs << 'spec'
     t.test_files = FileList['spec/**/*_spec.rb']
+    t.ruby_opts = ['-W:deprecated']
     t.warning = true
     t.verbose = true
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Ruby will Enable `frozen_string_literal` in 4.0 by default, see https://bugs.ruby-lang.org/issues/20205 and warns about them since 3.4 (when deprecation warning are enabled)

=> This PR adds 3.4 and head to out CI, and a warning about deprecation in rake test.