### PR TITLE
Save datatables state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+## [Unreleased]
+
+### Added
+
+### Changed
+- the table preferences (pagelength, column visibility) are stored in the local browser cache (@robertcheramy)
+
+### Fixed
+
+
 ## [0.15.1 – 2025-02-20]
 This minor release fixes javascript errors.
 

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -76,7 +76,8 @@
           className: 'btn-primary',
         }],
       autoWidth: false,
-      lengthMenu: [20, 50, 250, 500, { label: 'All', value: -1 }]
+      lengthMenu: [20, 50, 250, 500, { label: 'All', value: -1 }],
+      stateSave: true,
     });
 
     table.buttons(0,0).container().prependTo($('#oxButtons'));

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -6,6 +6,9 @@
       %button.btn.btn-primary{type: 'button', onclick: 'history.go();'}
         %i.bi.bi-arrow-clockwise
         Refresh
+      %button.btn.btn-primary#resetSearch{type: 'button'}
+        %i.bi.bi-eraser-fill
+        Reset search
       %button.btn.btn-primary#reload{type: 'button'}
         %i.bi.bi-repeat
         Update node list
@@ -82,6 +85,10 @@
 
     table.buttons(0,0).container().prependTo($('#oxButtons'));
     table.buttons(0,0).nodes().removeClass('btn-secondary');
+
+    $('#resetSearch').on('click', function() {
+        table.search('').draw();
+    });
   });
 
 

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -102,6 +102,7 @@
         }],
       autoWidth: false,
       lengthMenu: [20, 50, 250, 500, { label: 'All', value: -1 }],
+      stateSave: true,
     });
 
     table.buttons(0,0).container().prependTo($('#oxButtons'));

--- a/lib/oxidized/web/views/stats.haml
+++ b/lib/oxidized/web/views/stats.haml
@@ -8,6 +8,9 @@
       %button.btn.btn-primary{type: 'button', onclick: 'history.go();'}
         %i.bi.bi-arrow-clockwise
         Refresh
+      %button.btn.btn-primary#resetSearch{type: 'button'}
+        %i.bi.bi-eraser-fill
+        Reset search
 
 .row
   .table-responsive
@@ -107,4 +110,8 @@
 
     table.buttons(0,0).container().prependTo($('#oxButtons'));
     table.buttons(0,0).nodes().removeClass('btn-secondary');
+
+    $('#resetSearch').on('click', function() {
+        table.search('').draw();
+    });
   });


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR saves the state of datatables, permitting to permanently store the page length, column visibility or search string in the browser.

Closes #314
Closes #315
Closes #212
Closes #265