### PR TITLE
Fix vhosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - the table preferences (pagelength, column visibility) are stored in the local browser cache (@robertcheramy)
 
 ### Fixed
+- Allow connection to any virtual hosts + prepare extended configuration to specify which vhosts to accept. Fixes #298 (@robertcheramy)
 
 
 ## [0.15.1 – 2025-02-20]

--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -9,7 +9,7 @@ module Oxidized
       def initialize(nodes, configuration)
         require 'oxidized/web/webapp'
         if configuration.instance_of? Asetus::ConfigStruct
-          # New configuration syle: extentions.oxidized-web
+          # New configuration syle: extensions.oxidized-web
           addr = configuration.listen? || '127.0.0.1'
           port = configuration.port? || 8888
           uri = configuration.url_prefix? || ''

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -28,7 +28,7 @@ module Oxidized
       # :filter can be "group" or "model"
       # URL: /nodes/group/<GroupName>[.json]
       # URL: /nodes/model/<ModelName>[.json]
-      # an optional .json extention returns the data as JSON
+      # an optional .json extension returns the data as JSON
       #
       # as GroupName can include /, we use splat to match its value
       # and extract the optional ".json" with route_parse


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR specifies empty vhosts, so that sinatra doesn't block the access to oxidized when using a hostname instead of an ip address.  This fixes #298

It also prepares an extented configuration to specify which vhosts to accept. This part must be done in oxidized, but only after a new version of oxidized-web has been published.

