### PR TITLE
Stop puma from renaming the process and reacting on signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Gemfile.lock
 # npm files
 /node_modules/
 /.rake_tasks~
+.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update weblibs to the latest version
 
 ### Fixed
-
+- Run puma directly, so that it does not rename the oxidized process.
+  Fixes: 349 (@robertcheramy)
 
 ## [0.16.0 - 2025-03-25]
 This release introduces the possibility for an extended configuration of

--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'puma'
 
@@ -6,29 +8,18 @@ module Oxidized
     class Web
       attr_reader :thread
 
+      DEFAULT_HOST = '127.0.0.1'
+      DEFAULT_PORT = 8888
+      DEFAULT_URI_PREFIX = ''
+
       def initialize(nodes, configuration)
         require 'oxidized/web/webapp'
-        if configuration.instance_of? Asetus::ConfigStruct
-          # New configuration syle: extensions.oxidized-web
-          @addr = configuration.listen? || '127.0.0.1'
-          @port = configuration.port? || 8888
-          uri = configuration.url_prefix? || ''
-          vhosts = configuration.vhosts? || []
-        else
-          # Old configuration stlyle: "rest: 127.0.0.1:8888/prefix"
-          listen, uri = configuration.split '/'
-          @addr, _, @port = listen.rpartition ':'
-          unless port
-            @port = addr
-            @addr = nil
-          end
-          vhosts = []
-        end
-        uri = "/#{uri}"
+        @addr, @port, uri_prefix, vhosts = self.class.parse_configuration(configuration)
+        uri_prefix = "/#{uri_prefix}"
         WebApp.set :nodes, nodes
         WebApp.set :host_authorization, { permitted_hosts: vhosts }
         @app = Rack::Builder.new do
-          map uri do
+          map uri_prefix do
             run WebApp
           end
         end
@@ -41,6 +32,39 @@ module Oxidized
           Oxidized.logger.info "Oxidized-web server listening on #{@addr}:#{@port}"
           @server.run.join
         end
+      end
+
+      def self.parse_configuration(configuration)
+        if configuration.instance_of? Asetus::ConfigStruct
+          parse_new_configuration(configuration)
+        else
+          parse_legacy_configuration(configuration)
+        end
+      end
+
+      # New configuration style: extensions.oxidized-web
+      def self.parse_new_configuration(configuration)
+        addr = configuration.listen? || DEFAULT_HOST
+        port = configuration.port? || DEFAULT_PORT
+        uri_prefix = configuration.url_prefix? || DEFAULT_URI_PREFIX
+        vhosts = configuration.vhosts? || []
+
+        [addr, port, uri_prefix, vhosts]
+      end
+
+      # Legacy configuration style: "rest: 127.0.0.1:8888/prefix"
+      def self.parse_legacy_configuration(configuration)
+        listen, uri_prefix = configuration.split('/', 2)
+        addr, _, port = listen.rpartition ':'
+        unless port
+          port = addr
+          addr = nil
+        end
+        port = port.to_i
+        uri_prefix ||= DEFAULT_URI_PREFIX
+        vhosts = []
+
+        [addr, port, uri_prefix, vhosts]
       end
     end
   end

--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -6,6 +6,8 @@ require 'puma'
 module Oxidized
   module API
     class Web
+      include SemanticLogger::Loggable
+
       attr_reader :thread
 
       DEFAULT_HOST = '127.0.0.1'
@@ -29,7 +31,7 @@ module Oxidized
         @thread = Thread.new do
           @server = Puma::Server.new @app
           @server.add_tcp_listener @addr, @port
-          Oxidized.logger.info "Oxidized-web server listening on #{@addr}:#{@port}"
+          logger.info "Oxidized-web server listening on #{@addr}:#{@port}"
           @server.run.join
         end
       end

--- a/lib/oxidized/web.rb
+++ b/lib/oxidized/web.rb
@@ -1,34 +1,30 @@
 require 'json'
+require 'puma'
 
 module Oxidized
   module API
     class Web
-      require 'rack/handler/puma'
       attr_reader :thread
 
       def initialize(nodes, configuration)
         require 'oxidized/web/webapp'
         if configuration.instance_of? Asetus::ConfigStruct
           # New configuration syle: extensions.oxidized-web
-          addr = configuration.listen? || '127.0.0.1'
-          port = configuration.port? || 8888
+          @addr = configuration.listen? || '127.0.0.1'
+          @port = configuration.port? || 8888
           uri = configuration.url_prefix? || ''
           vhosts = configuration.vhosts? || []
         else
           # Old configuration stlyle: "rest: 127.0.0.1:8888/prefix"
           listen, uri = configuration.split '/'
-          addr, _, port = listen.rpartition ':'
+          @addr, _, @port = listen.rpartition ':'
           unless port
-            port = addr
-            addr = nil
+            @port = addr
+            @addr = nil
           end
           vhosts = []
         end
         uri = "/#{uri}"
-        @opts = {
-          Host: addr,
-          Port: port
-        }
         WebApp.set :nodes, nodes
         WebApp.set :host_authorization, { permitted_hosts: vhosts }
         @app = Rack::Builder.new do
@@ -40,8 +36,10 @@ module Oxidized
 
       def run
         @thread = Thread.new do
-          Rack::Handler::Puma.run @app, **@opts
-          exit!
+          @server = Puma::Server.new @app
+          @server.add_tcp_listener @addr, @port
+          Oxidized.logger.info "Oxidized-web server listening on #{@addr}:#{@port}"
+          @server.run.join
         end
       end
     end

--- a/oxidized-web.gemspec
+++ b/oxidized-web.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'htmlentities',        '~> 4.3'
   s.add_dependency 'json',                '~> 2.3'
   s.add_dependency 'ostruct',             '~> 0.6'
-  s.add_dependency 'oxidized',            '~> 0.31'
+  s.add_dependency 'oxidized',            '~> 0.34.0'
   s.add_dependency 'puma',                '>= 3.11.4'
   s.add_dependency 'sinatra',             '>= 1.4.6'
   s.add_dependency 'sinatra-contrib',     '>= 1.4.6'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,6 @@ SimpleCov.start
 require 'minitest/autorun'
 require 'rack/test'
 require 'oxidized'
+require 'oxidized/web'
 require 'oxidized/web/webapp'
 require 'mocha/minitest'

--- a/spec/web/node_spec.rb
+++ b/spec/web/node_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require_relative '../spec_helper'
 
 describe Oxidized::API::WebApp do
   include Rack::Test::Methods

--- a/spec/web/node_version_spec.rb
+++ b/spec/web/node_version_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require_relative '../spec_helper'
 
 describe Oxidized::API::WebApp do
   include Rack::Test::Methods

--- a/spec/web/nodes_spec.rb
+++ b/spec/web/nodes_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require_relative '../spec_helper'
 require 'json'
 
 describe Oxidized::API::WebApp do

--- a/spec/web/root_spec.rb
+++ b/spec/web/root_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require_relative '../spec_helper'
 
 describe Oxidized::API::WebApp do
   include Rack::Test::Methods

--- a/spec/web/webapp_spec.rb
+++ b/spec/web/webapp_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require_relative '../spec_helper'
 
 # Test helper methods in Oxidized::API::WebApp
 

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -1,0 +1,79 @@
+require_relative 'spec_helper'
+
+describe Oxidized::API::Web do
+  describe "#parse_legacy_configuration" do
+    test_cases = [
+      {
+        configuration: "192.168.1.100:9999",
+        expected: ["192.168.1.100", 9999, "", []],
+        description: "IP address and port"
+      },
+      {
+        configuration: "[::1]:8080",
+        expected: ["[::1]", 8080, "", []],
+        description: "IPv6 address with port"
+      },
+      {
+        configuration: "1234",
+        expected: ["", 1234, "", []],
+        description: "port only"
+      },
+      {
+        configuration: "0.0.0.0:9999/api",
+        expected: ["0.0.0.0", 9999, "api", []],
+        description: "host:port/prefix"
+      },
+      {
+        configuration: "8888/v1",
+        expected: ["", 8888, "v1", []],
+        description: "port/prefix"
+      },
+      {
+        configuration: "127.0.0.1:3000/api/v2",
+        expected: ["127.0.0.1", 3000, "api/v2", []],
+        description: "complex URI prefix"
+      },
+      {
+        configuration: "127.0.0.1:3000/",
+        expected: ["127.0.0.1", 3000, "", []],
+        description: "empty URI prefix after slash"
+      }
+    ]
+
+    test_cases.each do |test_case|
+      it "should parse #{test_case[:description]} correctly" do
+        result = Oxidized::API::Web.parse_legacy_configuration(test_case[:configuration])
+        expect(result).must_equal test_case[:expected]
+      end
+    end
+  end
+
+  describe "#parse_new_configuration" do
+    test_cases = [
+      {
+        configuration: Asetus::ConfigStruct.new(
+          {
+            'listen' => '0.0.0.0',
+            'port' => 3000,
+            'url_prefix' => '/api',
+            'vhosts' => ['example.com', 'test.com']
+          }
+        ),
+        expected: ['0.0.0.0', 3000, '/api', ['example.com', 'test.com']],
+        description: "all values provided"
+      },
+      {
+        configuration: Asetus::ConfigStruct.new,
+        expected: ['127.0.0.1', 8888, '', []],
+        description: "all default values"
+      }
+    ]
+
+    test_cases.each do |test_case|
+      it "should parse #{test_case[:description]} correctly" do
+        result = Oxidized::API::Web.parse_configuration(test_case[:configuration])
+        expect(result).must_equal test_case[:expected]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This is done by starting puma directly.

Close:  #349
