### PR TITLE
Hide sensible node vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Documentation of the configuration (@robertcheramy)
 
 ### Changed
-- Update weblibs to the latest version
+- Update weblibs to the latest version (@robertcheramy)
+- Depend on oxidized 0.34.0 (configuration of oxidized web as an extension) (@robertcheramy)
+- Use JSON to format the node metadata in /node/show (@robertcheramy)
 
 ### Fixed
 - Run puma directly, so that it does not rename the oxidized process. Fixes: 349 (@robertcheramy)
 - Display local time correctly and use epoch as timestamps in the URLs. Fixes: #258 and #356 (@robertcheramy)
+- Hide node vars when listed in the configuration entry hide_node_vars. Fixes: #344 (@robertcheramy)
 
 ## [0.16.0 - 2025-03-25]
 This release introduces the possibility for an extended configuration of
@@ -25,7 +29,7 @@ will only work with oxidized-web version 0.16.0 or later.
 
 ### Fixed
 - the table preferences (pagelength, column visibility, search) are stored in the local browser cache. Fixes #315 #314 #265 #211 (@robertcheramy)
-- Update "refresh" and "Upldate node list" to more meaningfull texts (@robertcheramy)
+- Update "refresh" and "Update node list" to more meaningful texts (@robertcheramy)
 
 ## [0.15.1 – 2025-02-20]
 This patch release fixes javascript errors.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,25 @@
 [![Build Status](https://github.com/ytti/oxidized-web/actions/workflows/ruby.yml/badge.svg)](https://github.com/ytti/oxidized-web/actions/workflows/ruby.yml)
 [![Gem Version](https://badge.fury.io/rb/oxidized-web.svg)](http://badge.fury.io/rb/oxidized-web)
 
-Web userinterface and RESTful API for Oxidized.
+Web user interface and RESTful API for Oxidized.
 
-This is not useful independently, see https://github.com/ytti/oxidized for install instructions.
+## Installation
+This is not useful independently, see https://github.com/ytti/oxidized for
+install instructions.
 
+Note: because of its dependencies, installing the `oxidized-web` gem will
+install `oxidized` automatically.
+
+## Configuration
+`oxidized-web` is configured through the configuration of `oxidized`,
+in the `extension` section. For details, see
+[docs/configuration.md](docs/configuration.md).
+
+## Development
 If you wonder how to run oxidized-web from git for development, have a look at
 [docs/development.md](docs/development.md).
 
 ## License and Copyright
-
 Copyright 2013-2015 Saku Ytti <saku@ytti.fi>
           2013-2015 Samer Abdel-Hafez <sam@arahant.net>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,90 @@
+# Basic configuration
+The RESTful API and web interface are enabled by installing the `oxidized-web`
+gem and configuring the `extensions.oxidized-web:` section in the configuration
+file:
+```yaml
+extensions:
+  oxidized-web:
+    load: true
+    # enter your configuration here
+```
+
+You can set the following parameter:
+- `load`: `true`/`false`: Enables or disables the `oxidized-web` extension
+  (default: `false`)
+- `listen`: Specifies the interface to bind to (default: `127.0.0.1`). Valid
+  options:
+  - `127.0.0.1`: Allows IPv4 connections from localhost only
+  - `'[::1]'`: Allows IPv6 connections from localhost only
+  - `<IPv4-Address>` or `'[<IPv6-Address>]'`: Binds to a specific interface
+  - `0.0.0.0`: Binds to any IPv4 interface
+  - `'[::]'`:  Binds to any IPv4 and IPv6 interface
+- `port`: Specifies the TCP port to listen to (default: `8888`)
+- `url_prefix`: Defines a URL prefix (default: no prefix)
+- `vhosts`: A list of virtual hosts to listen to. If not specified, it will
+  respond to any virtual host.
+
+## Examples
+
+```yaml
+# Listen on http://[::1]:8888/
+extensions:
+  oxidized-web:
+    load: true
+    listen: '[::1]'
+    port: 8888
+```
+
+```yaml
+# Listen on http://127.0.0.1:8888/
+extensions:
+  oxidized-web:
+    load: true
+    listen: 127.0.0.1
+    port: 8888
+```
+
+```yaml
+# Listen on http://[2001:db8:0:face:b001:0:dead:beaf]:8888/oxidized/
+extensions:
+  oxidized-web:
+    load: true
+    listen: '[2001:db8:0:face:b001:0:dead:beaf]'
+    port: 8888
+    url_prefix: oxidized
+```
+
+```yaml
+# Listen on http://10.0.0.1:8000/oxidized/
+extensions:
+  oxidized-web:
+    load: true
+    listen: 10.0.0.1
+    port: 8000
+    url_prefix: oxidized
+```
+
+```yaml
+# Listen on any interface to http://oxidized.rocks:8888 and
+# http://oxidized:8888
+extensions:
+  oxidized-web:
+    load: true
+    listen: '[::]'
+    url_prefix: oxidized
+    vhosts:
+     - oxidized.rocks
+     - oxidized
+```
+
+# Hide node vars
+Some node vars (enable, password) can contain sensible data. You can list the
+vars to be hidden under `hide_node_vars`:
+```yaml
+extensions:
+  oxidized-web:
+    load: true
+    hide_node_vars:
+     - enable
+     - password
+```

--- a/lib/oxidized/web/views/node.haml
+++ b/lib/oxidized/web/views/node.haml
@@ -14,7 +14,8 @@
       %a.link-dark.link-underline-opacity-0{title: 'update',
         href: url_for("/node/next/#{@data[:full_name]}")}
         %i.bi.bi-repeat
-    - out = '';PP.pp(@data,out)
     %pre.bg-body-tertiary.border.border-secondary-subtle.rounded
-      = preserve "#{out}"
+      %code
+        =escape_once(JSON.pretty_generate(@data))
+
 

--- a/spec/web/node/show_spec.rb
+++ b/spec/web/node/show_spec.rb
@@ -1,0 +1,100 @@
+require_relative '../../spec_helper'
+describe Oxidized::API::WebApp do
+  include Rack::Test::Methods
+
+  def app
+    Oxidized::API::WebApp
+  end
+
+  before do
+    @nodes = mock('Oxidized::Nodes')
+    app.set(:nodes, @nodes)
+
+    @serialized_node = {
+      name: "sw5",
+      full_name: "sw5.example.com",
+      ip: "10.42.12.42",
+      group: nil,
+      model: "ios",
+      last: {
+        start: Time.parse("2025-02-05 19:49:00 +0100"),
+        end: Time.parse("2025-02-05 19:49:10 +0100"),
+        status: :no_connection,
+        time: 10
+      },
+      vars: {
+        oxi: "dized",
+        enable: "secret_enable",
+        username: "oxidized",
+        password: "secret_password"
+      },
+      mtime: Time.parse("2025-02-05 19:49:11 +0100")
+    }
+  end
+
+  describe "get /node/show/:node" do
+    it "shows the metadata of a node" do
+      app.set(:configuration, { hide_node_vars: [] })
+      @nodes.expects(:show).with("sw5").returns(@serialized_node)
+
+      get '/node/show/sw5'
+      _(last_response.ok?).must_equal true
+      body = last_response.body
+
+      _(body).must_match(/secret_enable/)
+      _(body).must_match(/secret_password/)
+      _(body.include?(
+          "<code>{\n  &quot;name&quot;: &quot;sw5&quot;," \
+          "\n  &quot;full_name&quot;: &quot;sw5.example.com&quot;," \
+          "\n  &quot;ip&quot;: &quot;10.42.12.42&quot;," \
+          "\n  &quot;group&quot;: null,\n  &quot;model&quot;: &quot;ios&quot;," \
+          "\n  &quot;last&quot;: {" \
+          "\n    &quot;start&quot;: &quot;2025-02-05 19:49:00 +0100&quot;," \
+          "\n    &quot;end&quot;: &quot;2025-02-05 19:49:10 +0100&quot;," \
+          "\n    &quot;status&quot;: &quot;no_connection&quot;," \
+          "\n    &quot;time&quot;: 10\n  }," \
+          "\n  &quot;vars&quot;: {" \
+          "\n    &quot;oxi&quot;: &quot;dized&quot;," \
+          "\n    &quot;enable&quot;: &quot;secret_enable&quot;," \
+          "\n    &quot;username&quot;: &quot;oxidized&quot;," \
+          "\n    &quot;password&quot;: &quot;secret_password&quot;" \
+          "\n  },\n  &quot;mtime&quot;: &quot;2025-02-05 19:49:11 +0100&quot;" \
+          "\n}</code>"
+        )).must_equal true
+    end
+
+    it "hides vars in hide_node_vars" do
+      app.set(:configuration, { hide_node_vars: %i[enable password] })
+      @nodes.expects(:show).with("sw5").returns(@serialized_node)
+
+      get '/node/show/sw5'
+      _(last_response.ok?).must_equal true
+      body = last_response.body
+
+      _(body).wont_match(/secret_enable/)
+      _(body).wont_match(/secret_password/)
+      _(body).must_match(/&lt;hidden&gt;/)
+      _(body.include?(
+          "<code>{\n  &quot;name&quot;: &quot;sw5&quot;," \
+          "\n  &quot;full_name&quot;: &quot;sw5.example.com&quot;," \
+          "\n  &quot;ip&quot;: &quot;10.42.12.42&quot;," \
+          "\n  &quot;group&quot;: null,\n  &quot;model&quot;: &quot;ios&quot;," \
+          "\n  &quot;last&quot;: {" \
+          "\n    &quot;start&quot;: &quot;2025-02-05 19:49:00 +0100&quot;," \
+          "\n    &quot;end&quot;: &quot;2025-02-05 19:49:10 +0100&quot;," \
+          "\n    &quot;status&quot;: &quot;no_connection&quot;," \
+          "\n    &quot;time&quot;: 10\n  }," \
+          "\n  &quot;vars&quot;: {" \
+          "\n    &quot;oxi&quot;: &quot;dized&quot;," \
+          "\n    &quot;enable&quot;: &quot;&lt;hidden&gt;&quot;," \
+          "\n    &quot;username&quot;: &quot;oxidized&quot;," \
+          "\n    &quot;password&quot;: &quot;&lt;hidden&gt;&quot;" \
+          "\n  },\n  &quot;mtime&quot;: &quot;2025-02-05 19:49:11 +0100&quot;" \
+          "\n}</code>"
+        )).must_equal true
+
+      # The note data is not changed (deep copy with Marshal)
+      _(@serialized_node[:vars][:enable]).must_equal "secret_enable"
+    end
+  end
+end

--- a/spec/web/node/version_spec.rb
+++ b/spec/web/node/version_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
 describe Oxidized::API::WebApp do
   include Rack::Test::Methods
@@ -12,7 +12,7 @@ describe Oxidized::API::WebApp do
     app.set(:nodes, @nodes)
   end
 
-  describe '/node/version.?:format?' do
+  describe 'get /node/version.?:format?' do
     before do
       @versions = [
         { oid: "C006", time: Time.parse("2025-02-05 19:49:00 +0100") },
@@ -73,7 +73,7 @@ describe Oxidized::API::WebApp do
     end
   end
 
-  describe '/node/version/view.?:format?' do
+  describe 'get /node/version/view.?:format?' do
     it 'fetches a previous version from git' do
       @nodes.expects(:get_version).with('sw5', '', 'c8aa93cab5').returns('Old configuration of sw5')
 
@@ -124,7 +124,7 @@ describe Oxidized::API::WebApp do
     end
   end
 
-  describe '/node/version/diffs' do
+  describe 'get /node/version/diffs' do
     it 'diffs a version with the latest configuration' do
       @versions = [
         { oid: "C006", time: Time.parse("2025-02-05 19:49:00 +0100") },

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -4,39 +4,46 @@ describe Oxidized::API::Web do
   describe "#parse_legacy_configuration" do
     test_cases = [
       {
-        configuration: "192.168.1.100:9999",
-        expected: ["192.168.1.100", 9999, "", []],
-        description: "IP address and port"
+        configuration: '192.168.1.100:9999',
+        expected: { addr: '192.168.1.100', port: 9999, uri_prefix: '/',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'IP address and port'
       },
       {
-        configuration: "[::1]:8080",
-        expected: ["[::1]", 8080, "", []],
-        description: "IPv6 address with port"
+        configuration: '[::1]:8080',
+        expected: { addr: '[::1]', port: 8080, uri_prefix: '/',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'IPv6 address with port'
       },
       {
-        configuration: "1234",
-        expected: ["", 1234, "", []],
-        description: "port only"
+        configuration: '1234',
+        expected: { addr: '', port: 1234, uri_prefix: '/',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'port only'
       },
       {
-        configuration: "0.0.0.0:9999/api",
-        expected: ["0.0.0.0", 9999, "api", []],
-        description: "host:port/prefix"
+        configuration: '0.0.0.0:9999/api',
+        expected: { addr: '0.0.0.0', port: 9999, uri_prefix: '/api',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'host:port/prefix'
       },
       {
-        configuration: "8888/v1",
-        expected: ["", 8888, "v1", []],
-        description: "port/prefix"
+        configuration: '8888/v1',
+        expected: { addr: '', port: 8888, uri_prefix: '/v1',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'port/prefix'
       },
       {
-        configuration: "127.0.0.1:3000/api/v2",
-        expected: ["127.0.0.1", 3000, "api/v2", []],
-        description: "complex URI prefix"
+        configuration: '127.0.0.1:3000/api/v2',
+        expected: { addr: '127.0.0.1', port: 3000, uri_prefix: '/api/v2',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'complex URI prefix'
       },
       {
-        configuration: "127.0.0.1:3000/",
-        expected: ["127.0.0.1", 3000, "", []],
-        description: "empty URI prefix after slash"
+        configuration: '127.0.0.1:3000/',
+        expected: { addr: '127.0.0.1', port: 3000, uri_prefix: '/',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'empty URI prefix after slash'
       }
     ]
 
@@ -56,16 +63,28 @@ describe Oxidized::API::Web do
             'listen' => '0.0.0.0',
             'port' => 3000,
             'url_prefix' => '/api',
-            'vhosts' => ['example.com', 'test.com']
+            'vhosts' => ['example.com', 'test.com'],
+            'hide_node_vars' => %w[enable password]
           }
         ),
-        expected: ['0.0.0.0', 3000, '/api', ['example.com', 'test.com']],
-        description: "all values provided"
+        expected: { addr: '0.0.0.0', port: 3000, uri_prefix: '/api',
+                    vhosts: ["example.com", "test.com"],
+                    hide_node_vars: %i[enable password] },
+        description: 'all values provided'
       },
       {
         configuration: Asetus::ConfigStruct.new,
-        expected: ['127.0.0.1', 8888, '', []],
-        description: "all default values"
+        expected: { addr: '127.0.0.1', port: 8888, uri_prefix: '/',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'all default values'
+      },
+      {
+        configuration: Asetus::ConfigStruct.new(
+          { 'hide_node_vars' => 'enable' }
+        ),
+        expected: { addr: '127.0.0.1', port: 8888, uri_prefix: '/',
+                    vhosts: [], hide_node_vars: [] },
+        description: 'return an empty list when hide_node_vars not a hash'
       }
     ]
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
- Hide node vars when listed in the configuration entry hide_node_vars. Fixes: #344 (@robertcheramy)
- Use JSON to format the node metadata in /node/show (@robertcheramy)


<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Fixes #344
