### PR TITLE
fix: URL-encode node names in web UI links and redirects (#396, #414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
-- Fix version comparison for nodes whose name contains spaces or other special characters (e.g. `router1 [192.168.1.1]`): the diff redirect and links now URL-encode the node name / see issue #396
+- URL-encode node names in web UI links and redirects, so nodes whose name contains spaces, `+`, brackets or other special characters (e.g. `router1 [192.168.1.1]`, `router1+(test123+)`) work on the version/diff pages / see issues #396 and #414
 
 
 ## [0.18.1 – 2026-01-19]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- Fix version comparison for nodes whose name contains spaces or other special characters (e.g. `router1 [192.168.1.1]`): the diff redirect and links now URL-encode the node name / see issue #396
 
 
 ## [0.18.1 – 2026-01-19]

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -5,7 +5,7 @@
         - node_full = "#{@info[:group]}/#{@info[:node]}"
       - else
         - node_full = "#{@info[:node]}"
-      %a{href: url_for("/node/version?node_full=#{node_full}")} versions
+      %a{href: url_for("/node/version?node_full=#{url_param node_full}")} versions
       \/ Diff version #{@info[:num]} - #{@info[:num2]} for node
       %b #{@info[:node]}
 .row

--- a/lib/oxidized/web/views/diffs.haml
+++ b/lib/oxidized/web/views/diffs.haml
@@ -20,7 +20,7 @@
 
 .row
   .col-sm-6
-    - params = "node=#{@info[:node]}&group=#{@info[:group]}&oid=#{@info[:oid]}"
+    - params = "node=#{url_param @info[:node]}&group=#{url_param @info[:group]}&oid=#{url_param @info[:oid]}"
     - params = "#{params}&epoch=#{@info[:time].to_i}&num=#{@info[:num]}"
     %form{action: url_for("/node/version/diffs?#{params}"), method: 'post', role: 'form'}
       .form-group

--- a/lib/oxidized/web/views/node.haml
+++ b/lib/oxidized/web/views/node.haml
@@ -9,7 +9,7 @@
         href: url_for("/node/fetch/#{@data[:full_name]}")}
         %i.bi.bi-cloud-download
       %a.link-body-emphasis.link-underline-opacity-0{title: 'versions',
-        href: url_for("/node/version?node_full=#{@data[:full_name]}")}
+        href: url_for("/node/version?node_full=#{url_param @data[:full_name]}")}
         %i.bi.bi-stack
       %a.link-body-emphasis.link-underline-opacity-0{title: 'update',
         href: url_for("/node/next/#{@data[:full_name]}")}

--- a/lib/oxidized/web/views/nodes.haml
+++ b/lib/oxidized/web/views/nodes.haml
@@ -50,7 +50,7 @@
                 %i.bi.bi-cloud-download
               &nbsp;&nbsp;
               %a.link-body-emphasis.link-underline-opacity-0{title: 'Versions',
-                href: url_for("/node/version?node_full=#{node[:full_name]}")}
+                href: url_for("/node/version?node_full=#{url_param node[:full_name]}")}
                 %i.bi.bi-stack
               &nbsp;&nbsp;
               %a.link-body-emphasis.link-underline-opacity-0{title: 'Update configuration',

--- a/lib/oxidized/web/views/version.haml
+++ b/lib/oxidized/web/views/version.haml
@@ -2,9 +2,9 @@
   .col-8
     %h4
       - if @info[:group] != ''
-        - params = "node_full=#{@info[:group] + '/' + @info[:node]}"
+        - params = "node_full=#{url_param(@info[:group] + '/' + @info[:node])}"
       - else
-        - params = "node_full=#{@info[:node]}"
+        - params = "node_full=#{url_param @info[:node]}"
       %a{href: url_for("/node/version?#{params}")} versions
       \/ version #{@info[:num]} for node
       %b #{@info[:node]}

--- a/lib/oxidized/web/views/versions.haml
+++ b/lib/oxidized/web/views/versions.haml
@@ -28,7 +28,7 @@
             %td.time{ epoch: x[:time].to_i }= x[:time]
             %td #{time_from_now x[:time]}
             %td
-              - params = "node=#{@node}&group=#{@group}&oid=#{x[:oid]}"
+              - params = "node=#{url_param @node}&group=#{url_param @group}&oid=#{url_param x[:oid]}"
               - params = "#{params}&epoch=#{x[:time].to_i}&num=#{nb}"
               %a.link-body-emphasis.link-underline-opacity-0{title: 'configuration',
                  href: url_for("/node/version/view?#{params}")}

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -218,7 +218,9 @@ module Oxidized
 
       # used for diff between 2 distant commit
       post '/node/version/diffs' do
-        redirect url_for("/node/version/diffs?node=#{params[:node]}&group=#{params[:group]}&oid=#{params[:oid]}&epoch=#{params[:epoch]}&num=#{params[:num]}&oid2=#{params[:oid2]}")
+        redirect url_for("/node/version/diffs?node=#{url_param params[:node]}&group=#{url_param params[:group]}" \
+                         "&oid=#{url_param params[:oid]}&epoch=#{url_param params[:epoch]}" \
+                         "&num=#{url_param params[:num]}&oid2=#{url_param params[:oid2]}")
       end
 
       # Taken von Haml 5.0, so it still works in 6.0
@@ -261,6 +263,13 @@ module Oxidized
           json = true
         end
         [e.join('.'), json]
+      end
+
+      # URL-encode a query-string value so node names containing spaces or other
+      # special characters (e.g. "router1 [192.168.1.1]") survive the round-trip
+      # through generated links and redirects. See issue #396.
+      def url_param(value)
+        Rack::Utils.escape(value.to_s)
       end
 
       # give the time elapsed between now and a date (Time object)

--- a/spec/web/node/version_spec.rb
+++ b/spec/web/node/version_spec.rb
@@ -158,4 +158,21 @@ describe Oxidized::API::WebApp do
         )).must_equal true
     end
   end
+
+  describe 'post /node/version/diffs' do
+    # issue #396: selecting a second version to compare failed when the node
+    # name contained spaces/brackets, because the POST handler built the
+    # redirect URL by raw string interpolation. The redirect must be encoded.
+    it 'url-encodes node names with special characters in the redirect' do
+      post '/node/version/diffs',
+           node: 'router1 [192.168.1.1]', group: '', oid: 'C006',
+           epoch: '1738781340', num: '3', oid2: 'C003'
+
+      _(last_response.status).must_equal 302
+      location = last_response.headers['Location']
+      _(location.include?('node=router1+%5B192.168.1.1%5D')).must_equal true
+      _(location.include?('router1 [')).must_equal false
+      _(location.include?('oid2=C003')).must_equal true
+    end
+  end
 end

--- a/spec/web/nodes_encoding_spec.rb
+++ b/spec/web/nodes_encoding_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper'
+
+describe Oxidized::API::WebApp do
+  include Rack::Test::Methods
+
+  def app
+    Oxidized::API::WebApp
+  end
+
+  # issue #414: a "+" (and other special characters) in a node name must be
+  # URL-encoded in the ?node_full= links. Otherwise the "+" in the query string
+  # is decoded to a space server-side and the versions page fails to load.
+  it 'url-encodes node_full in the node-list versions link' do
+    nodes = mock('Oxidized::Nodes')
+    nodes.expects(:list).returns(
+      [{ name: 'router1+(test123+)', full_name: 'default/router1+(test123+)',
+         ip: '10.0.0.1', model: 'ios', group: 'default',
+         status: 'success', time: 'time', mtime: 'mtime' }]
+    )
+    app.set(:nodes, nodes)
+
+    get '/nodes'
+    _(last_response.ok?).must_equal true
+    _(last_response.body).must_include 'node_full=default%2Frouter1%2B%28test123%2B%29'
+    _(last_response.body.include?('node_full=default/router1+(test123+)')).must_equal false
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Two related bugs with the same root cause: node names are interpolated into web
UI URLs **without URL-encoding**, so nodes whose names contain special characters
produce broken links.

### #396 — spaces break version comparison

For a node like `router1 [192.168.1.1]`, the first diff works but selecting a
second version to compare shows **"No differences available."** The
`POST /node/version/diffs` handler redirected with an unencoded `Location:`
header; the raw space corrupted the query, the follow-up `GET` got a truncated
`node`, and no diff was found. (The first comparison only worked because a
browser auto-encodes spaces in an `<a href>`.)

### #414 — `+` breaks the versions page

For a node like `router1+(test123+)`, opening `/node/version?node_full=…` fails,
because a `+` in a query string is decoded to a space server-side. The
`?node_full=` links were built by raw interpolation of `full_name`.

### Fix

Add a small `url_param` helper (`Rack::Utils.escape`) and apply it everywhere a
node name is interpolated into a URL:

- `POST /node/version/diffs` redirect (`webapp.rb`) — #396
- diff form params + compare link (`diffs.haml`, `versions.haml`) — #396
- `?node_full=` links (`nodes.haml`, `node.haml`, `diffs.haml`, `version.haml`) — #414

Output is **byte-identical** for names without special characters, so existing
behaviour and tests are unchanged.

The `/node/fetch/…` and `/node/next/…` **path** links are intentionally left as-is:
they rely on the literal `/` group separator (encoding it would break routing),
and `+` is not space-decoded in a path segment.

### Tests

- `post /node/version/diffs` asserts the redirect `Location` is encoded for
  `router1 [192.168.1.1]` (#396).
- `get /nodes` asserts the `?node_full=` link is encoded for `router1+(test123+)` (#414).

Closes #396
Closes #414
