### PR TITLE
Encode JSON output with the standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Remove the no longer needed escape_once helper call in node.haml, relying on HAML's global escape_html instead (@robertcheramy)
 - Update web libraries to the latest versions (@robertcheramy)
+- Encode JSON output with the standard library instead of Sinatra's json helper (@robertcheramy)
 
 ### Fixed
 - Fix XSS vulnerability (CWE-79) by enabling HAML's escape_html globally; user-controlled values in node names, group names, model names, and URL parameters are now HTML-escaped in all templates (@mattimustang)

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ task :test do
     t.test_files = FileList['spec/**/*_spec.rb']
     t.ruby_opts = ['-W:deprecated']
     t.warning = true
-    t.verbose = true
+    t.verbose = false
   end
 end
 

--- a/lib/oxidized/web/webapp.rb
+++ b/lib/oxidized/web/webapp.rb
@@ -1,5 +1,4 @@
 require 'sinatra/base'
-require 'sinatra/json'
 require 'sinatra/url_for'
 require 'tilt/haml'
 require 'htmlentities'
@@ -229,10 +228,11 @@ module Oxidized
 
       def out(template = :text)
         if @json || (params[:format] == 'json')
+          content_type :json
           if @data.is_a?(String)
-            json @data.lines
+            JSON.generate(@data.lines)
           else
-            json @data
+            JSON.generate(@data)
           end
         elsif (template == :text) || (params[:format] == 'text')
           content_type :text


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Encode JSON output with the standard library instead of Sinatra's json helper, avoiding the deprecated MultiJson.encode call

Also set rake test verbositiy to false.
